### PR TITLE
Mergeado de pelisalacarta-ce el fix de la videoteca + fix de búsqueda de nuevos episodios.

### DIFF
--- a/plugin.video.alfa/core/channeltools.py
+++ b/plugin.video.alfa/core/channeltools.py
@@ -18,7 +18,7 @@ def is_adult(channel_name):
     channel_parameters = get_channel_parameters(channel_name)
     return channel_parameters["adult"]
 
-def is_active(channel_name):
+def is_enabled(channel_name):
     logger.info("channel_name=" + channel_name)
     return get_channel_parameters(channel_name)["active"] and get_channel_setting("enabled", channel = channel_name, default = True)
 

--- a/plugin.video.alfa/core/channeltools.py
+++ b/plugin.video.alfa/core/channeltools.py
@@ -20,8 +20,7 @@ def is_adult(channel_name):
 
 def is_active(channel_name):
     logger.info("channel_name=" + channel_name)
-    channel_parameters = get_channel_parameters(channel_name)
-    return channel_parameters["active"]
+    return get_channel_parameters(channel_name)["active"] and get_channel_setting("enabled", channel = channel_name, default = True)
 
 def get_channel_parameters(channel_name):
     global dict_channels_parameters

--- a/plugin.video.alfa/core/channeltools.py
+++ b/plugin.video.alfa/core/channeltools.py
@@ -18,6 +18,10 @@ def is_adult(channel_name):
     channel_parameters = get_channel_parameters(channel_name)
     return channel_parameters["adult"]
 
+def is_active(channel_name):
+    logger.info("channel_name=" + channel_name)
+    channel_parameters = get_channel_parameters(channel_name)
+    return channel_parameters["active"]
 
 def get_channel_parameters(channel_name):
     global dict_channels_parameters

--- a/plugin.video.alfa/videolibrary_service.py
+++ b/plugin.video.alfa/videolibrary_service.py
@@ -25,9 +25,9 @@ def update(path, p_dialog, i, t, serie, overwrite):
         serie.channel = channel
         serie.url = url
 
-        channel_active = channeltools.is_active(channel)
+        channel_enabled = channeltools.is_enabled(channel)
 
-        if channel_active:
+        if channel_enabled:
 
             heading = 'Actualizando videoteca....'
             p_dialog.update(int(math.ceil((i + 1) * t)), heading, "%s: %s" % (serie.contentSerieName,

--- a/plugin.video.alfa/videolibrary_service.py
+++ b/plugin.video.alfa/videolibrary_service.py
@@ -11,6 +11,7 @@ import threading
 from core import config
 from core import filetools
 from core import logger
+from core import channeltools
 from core import videolibrarytools
 from platformcode import platformtools
 
@@ -24,7 +25,7 @@ def update(path, p_dialog, i, t, serie, overwrite):
         serie.channel = channel
         serie.url = url
 
-        channel_active = config.get_setting("active", channel=channel, default=False)
+        channel_active = channeltools.is_active(channel)
 
         if channel_active:
 


### PR DESCRIPTION
Me ha sorprendido añadir todas las series de pelisalacarta y comprobar que las series se iban machacnado y la biblioteca dejaba de actualizarse.

Esto era algo que pasaba en pelisalacarta, pero se acabó solucionando, y así está en el -ce (https://github.com/pelisalacarta-ce/pelisalacarta-ce/blob/master/python/main-classic/platformcode/xbmc_library.py#L390), del que supuestamente este es fork, pero el código es anterior.

Así pues he recuperado el fix de la concurrencia, pero he de decir que no funciona igual que en pelisalacarta-ce, no se si es porque han actualizado Kodi o porque habéis tocado algo en otro lado del addon, eso si, funciona mucho mejor que el código que hay actualmente.

Con el código actual añades una serie larga y otra después y se para la actualización y te quedas sin la que has añadido y sin la primera. El motivo es que el thread creado es completamente inútil ya que no hay objetos compartidos entre las 2 llamadas (en concreto el lock) y se crea un segundo thread que lanza otro update... machacando el primero.

Este código que mergeo en -ce provocaba un bloqueo en estos extraños casos (inapreciables si se provocaban por auto-actualización) hasta que podía actualizar. Para la actualización esto irá bien ya que lo genera el propio addon: serie por serie va actualizando si hay algo nuevo, y se bloqueará cuando esté escaneando, pero eso es solo una pequeña notificación arriba. También funcionará para los casos de nuevas instalaciones y recuperen el tvshow.nfo (como he realizado yo al traérmelos).

Sin embargo lo que no esperaba es que no se bloquea si se añaden 2 series navegando por el addon: Si se va a un canal y se añade una serie larga, por ejemplo Anatomía de Grey, que tardará un buen rato en actualizar, y vas hacia atrás y pones otra la interfaz no se bloquea, Kodi o este nuevo addon crea un nuevo thread en un punto previo a este. Creo que es Kodi ya que mirando donde se crean Threads no parece que sea un nuevo comportamiento de este addon. ¿Y esto que supone? Pues que este caso concreto que estoy diciendo en este momento va perfecto: Se acaba de añadir la primera y después, sin bloqueo alguno, se añade la segunda.

Pero si en vez de quedarnos ahí añadimos una 3º, 4º.... (mientras la 1º estaba aun escaneando) habrán 3 o 4 threads que estarán a la espera en el "IsScaning", cuando acabe la primera varios de ellos verán que ha acabado y lanzará su scan (siempre veo 2) que se machacarán entre ellos (el bug que hay ahora mismo sin este parche) y no se escanearán, pero si hay una 3º puede que tenga suerte y esta si se cuele (2 se matan entre ellos y el 3º se cuela)

En resumen:
- Con el parche se hace seguro la actualización (al abrir Kodi, por ejemplo) y se mejora añadir varias series, pero ahora mismo, al menos en la última versión de Kodi, no del todo, pero es bastante mejor que lo que hay ahora.