### PR TITLE
Limpiar episodios de seriesblanco

### DIFF
--- a/plugin.video.alfa/channels/seriesblanco.py
+++ b/plugin.video.alfa/channels/seriesblanco.py
@@ -190,6 +190,7 @@ def episodios(item):
     episodes = re.findall("<tr.*?href=['\"](?P<url>[^'\"]+).+?>(?P<title>.+?)</a>.*?<td>(?P<flags>.*?)</td>", data,
                           re.MULTILINE | re.DOTALL)
     for url, title, flags in episodes:
+        title = title.replace("<span itemprop='episodeNumber'>", "").replace("</span>", "")
         idiomas = " ".join(["[%s]" % IDIOMAS.get(language, "OVOS") for language in
                             re.findall("banderas/([^\.]+)", flags, re.MULTILINE)])
         filter_lang = idiomas.replace("[", "").replace("]", "").split(" ")


### PR DESCRIPTION
Han puesto en el listado de episodios un tag span HTML. Tal vez con sacar solo el número de dentro ya bastaría, pero como no se si en algún lado hay nombres de episodios lo dejo igual, solo que reemplazando esos tags por "".