### PR TITLE
[mediaserver] Añadir link original en el footer

### DIFF
--- a/mediaserver/platformcode/controllers/html.py
+++ b/mediaserver/platformcode/controllers/html.py
@@ -113,6 +113,7 @@ class platform(Platformtools):
         JsonData["data"]["viewmode"] = parent_item.viewmode
         JsonData["data"]["category"] = parent_item.category.capitalize()
         JsonData["data"]["host"] = self.controller.host
+        if parent_item.url: JsonData["data"]["url"] = parent_item.url
 
         # Recorremos el itemlist
         for item in itemlist:

--- a/mediaserver/platformcode/template/js/protocol.js
+++ b/mediaserver/platformcode/template/js/protocol.js
@@ -79,6 +79,17 @@ function get_response(data) {
 
         nav_history.newResponse(item_list, data.category);
 
+        currentWebLink = document.getElementById("current_web_link")
+        if (currentWebLink) {
+            if (data.url) {
+                currentWebLink.style.display = "block";
+                currentWebLink.href = data.url;
+            }
+            else {
+                currentWebLink.style.display = "none";
+            }
+        }
+
         //console.debug(nav_history)
         send_data({
             "id": response.id,

--- a/mediaserver/platformcode/template/page.html
+++ b/mediaserver/platformcode/template/page.html
@@ -129,7 +129,7 @@
 				<a href="javascript:void(0)" onmouseover="this.focus()" onmouseout="this.blur()" onclick="send_data({'id':this.parentNode.parentNode.RequestID, 'result': 6})"></a>
 				<a href="javascript:void(0)" onmouseover="this.focus()" onmouseout="this.blur()" onclick="send_data({'id':this.parentNode.parentNode.RequestID, 'result': 7})"></a>
 				<a href="javascript:void(0)" onmouseover="this.focus()" onmouseout="this.blur()" onclick="send_data({'id':this.parentNode.parentNode.RequestID, 'result': 8})"></a>
-            </div>			
+            </div>
             <div class="window_footer" id="window_footer">
                 <a href="javascript:void(0)" class="control_button button_ok" onmouseover="this.focus()" onclick="send_data({'id':this.parentNode.parentNode.RequestID, 'result':true});dialog.closeall();loading.show();">Aceptar</a>
                 <a href="javascript:void(0)" class="control_button button_close" onmouseover="this.focus()" onclick="send_data({'id':this.parentNode.parentNode.RequestID, 'result':null });dialog.closeall();">Cancelar</a>
@@ -214,7 +214,7 @@
                 <div class="left">
                 </div>
                 <div class="links">
-                    <a href="#">Saber más sobre Alfa</a> | <a href="#">Foro</a>
+                    <a href="#" id="current_web_link" target="_blank" hidden>Abrir web original</a>
                 </div>
                 <div class="status" id="status">Desconectado</div>
             </div>


### PR DESCRIPTION
Hay veces que Alfa/pelisalacarta falla constantemente: links borrados, servers o webs que cambian, o simplemente servers para los que no hay soporte; y decides ir a la web original para ver si allí funciona algo.

En este caso siempre hecho en falta poder entrar directamente: ya he navegado por el mediaserver y el tiene la URL, sin embargo ahora tengo que ir a la web original y volver a buscar, etc. Eso sin contar con que algunas tienen una publicidad ultra-agresiva (principal motivo que tengo para usar mediaserver).

Es por ello que me he realizado este cambio que yo voy a usar, simplemente lo comparto aquí por si os interesa mergearlo: Poner un link en la parte inferior al la URL que Alfa está mostrando de la web original: item.url.

He borrado los 2 enlaces que habían heredados de pelisalacarta ya que no hacían nada (apuntaban a #, estaría bien que se añadiera uno al GitHub, pero bueno, por ahora los quito, lo podéis editar vosotros para dejarlo a vuestro gusto)

Otra cosa que quería poner, pero no doy con la tecla aun, es que al darle a un torrent/magnet (es decir, algo que se reproduzca con el server torrent) me salga una opción de mostrar o copiar al portapapeles el link original. Si se mostrara algo en un <a hrdef="URL">Link Original</a> se le podría hacer click o copiar con el botón derecho, así que me parece lo más completo, de esa forma podríamos bajar o click el magnet/torrent y que nuestro cliente local lo abriera.

Lo dejo comentado como idea para el que hace la Mediaserver, por si le interesa como futuro cambio.