### PR TITLE
[mediaserver] Añadir link original en el footer

### DIFF
--- a/mediaserver/platformcode/controllers/html.py
+++ b/mediaserver/platformcode/controllers/html.py
@@ -113,6 +113,7 @@ class platform(Platformtools):
         JsonData["data"]["viewmode"] = parent_item.viewmode
         JsonData["data"]["category"] = parent_item.category.capitalize()
         JsonData["data"]["host"] = self.controller.host
+        if parent_item.url: JsonData["data"]["url"] = parent_item.url
 
         # Recorremos el itemlist
         for item in itemlist:

--- a/mediaserver/platformcode/template/js/protocol.js
+++ b/mediaserver/platformcode/template/js/protocol.js
@@ -77,7 +77,9 @@ function get_response(data) {
         document.getElementById("itemlist").scrollTop = 0;
 		show_images();
 
-        nav_history.newResponse(item_list, data.category);
+        nav_history.newResponse(item_list, data.category, data.url);
+
+        set_original_url(data.url)
 
         //console.debug(nav_history)
         send_data({

--- a/mediaserver/platformcode/template/js/ui.js
+++ b/mediaserver/platformcode/template/js/ui.js
@@ -104,6 +104,19 @@ function image_error(thumbnail) {
 	};
 };
 
+function set_original_url(url){
+    currentWebLink = document.getElementById("current_web_link")
+    if (currentWebLink) {
+        if (url) {
+            currentWebLink.style.display = "block";
+            currentWebLink.href = url;
+        }
+        else {
+            currentWebLink.style.display = "none";
+        }
+    }
+}
+
 function show_images(){
 	var container = document.getElementById("itemlist");
     var images = container.getElementsByTagName("img");

--- a/mediaserver/platformcode/template/js/ui.js
+++ b/mediaserver/platformcode/template/js/ui.js
@@ -94,7 +94,7 @@ function focus_element(element) {
 function image_error(thumbnail) {
     var src = thumbnail.src;
     if (thumbnail.src.indexOf(domain) == 0) {
-        thumbnail.src = "http://media.tvalacarta.info/pelisalacarta/thumb_folder2.png";
+        thumbnail.src = "https://github.com/alfa-addon/addon/raw/master/plugin.video.alfa/resources/media/general/default/thumb_folder.png";
     }
 	else {
 		thumbnail.src = domain + "/proxy/" + encodeURIComponent(btoa(thumbnail.src));

--- a/mediaserver/platformcode/template/js/vars.js
+++ b/mediaserver/platformcode/template/js/vars.js
@@ -68,7 +68,7 @@ var nav_history = {
             this.states[this.current].end = new Date().getTime();
             this.states[this.current].data = data;
             this.states[this.current].category = category;
-            this.states[this.current].url = url;
+            this.states[this.current].source_url = url;
             this.confirmed = true;
             if (settings.builtin_history && !this.from_nav) {
                 if (this.current > 0) {
@@ -87,7 +87,7 @@ var nav_history = {
             this.states[this.current].end = new Date().getTime();
             this.states[this.current].data = data;
             this.states[this.current].category = category;
-            this.states[this.current].url = url;
+            this.states[this.current].source_url = url;
             this.states = this.states.slice(0, this.current + 1);
         }
 		this.from_nav = false;
@@ -118,7 +118,7 @@ var nav_history = {
         if (this.states[this.current].end - this.states[this.current].start > this.cache) {
             document.getElementById("itemlist").innerHTML = this.states[this.current].data.join("");
             set_category(this.states[this.current].category)
-            set_original_url(this.states[this.current].url)
+            set_original_url(this.states[this.current].source_url)
             if (this.states[this.current].focus >= 0) {
                 document.getElementById("itemlist").children[this.states[this.current].focus].children[0].focus();
             }

--- a/mediaserver/platformcode/template/js/vars.js
+++ b/mediaserver/platformcode/template/js/vars.js
@@ -59,7 +59,7 @@ var nav_history = {
             }
         }
     },
-    "newResponse": function (data, category) {
+    "newResponse": function (data, category, url) {
         if (!this.confirmed) {
 			if (this.states[this.current].focus >= 0) {
                 document.getElementById("itemlist").children[this.states[this.current].focus].children[0].focus();
@@ -68,6 +68,7 @@ var nav_history = {
             this.states[this.current].end = new Date().getTime();
             this.states[this.current].data = data;
             this.states[this.current].category = category;
+            this.states[this.current].url = url;
             this.confirmed = true;
             if (settings.builtin_history && !this.from_nav) {
                 if (this.current > 0) {
@@ -86,6 +87,7 @@ var nav_history = {
             this.states[this.current].end = new Date().getTime();
             this.states[this.current].data = data;
             this.states[this.current].category = category;
+            this.states[this.current].url = url;
             this.states = this.states.slice(0, this.current + 1);
         }
 		this.from_nav = false;
@@ -116,6 +118,7 @@ var nav_history = {
         if (this.states[this.current].end - this.states[this.current].start > this.cache) {
             document.getElementById("itemlist").innerHTML = this.states[this.current].data.join("");
             set_category(this.states[this.current].category)
+            set_original_url(this.states[this.current].url)
             if (this.states[this.current].focus >= 0) {
                 document.getElementById("itemlist").children[this.states[this.current].focus].children[0].focus();
             }

--- a/mediaserver/platformcode/template/page.html
+++ b/mediaserver/platformcode/template/page.html
@@ -129,7 +129,7 @@
 				<a href="javascript:void(0)" onmouseover="this.focus()" onmouseout="this.blur()" onclick="send_data({'id':this.parentNode.parentNode.RequestID, 'result': 6})"></a>
 				<a href="javascript:void(0)" onmouseover="this.focus()" onmouseout="this.blur()" onclick="send_data({'id':this.parentNode.parentNode.RequestID, 'result': 7})"></a>
 				<a href="javascript:void(0)" onmouseover="this.focus()" onmouseout="this.blur()" onclick="send_data({'id':this.parentNode.parentNode.RequestID, 'result': 8})"></a>
-            </div>			
+            </div>
             <div class="window_footer" id="window_footer">
                 <a href="javascript:void(0)" class="control_button button_ok" onmouseover="this.focus()" onclick="send_data({'id':this.parentNode.parentNode.RequestID, 'result':true});dialog.closeall();loading.show();">Aceptar</a>
                 <a href="javascript:void(0)" class="control_button button_close" onmouseover="this.focus()" onclick="send_data({'id':this.parentNode.parentNode.RequestID, 'result':null });dialog.closeall();">Cancelar</a>
@@ -214,7 +214,7 @@
                 <div class="left">
                 </div>
                 <div class="links">
-                    <a href="#">Saber más sobre Alfa</a> | <a href="#">Foro</a>
+                    <a href="#" id="current_web_link" target="_blank" hidden>Abrir web original</a>
                 </div>
                 <div class="status" id="status">Desconectado</div>
             </div>


### PR DESCRIPTION
Hay veces que Alfa/pelisalacarta falla constantemente: links borrados, webs que cambian, o simplemente servers para los que no hay soporte; y decides ir a la web original para ver si allí funciona algo.

En este caso siempre echo en falta poder entrar directamente: ya he navegado por el mediaserver y el tiene la URL, sin embargo ahora tengo que ir a la web original y volver a buscar, etc. Eso sin contar con que algunas tienen una publicidad ultra-agresiva (principal motivo que tengo para usar mediaserver).

Es por ello que me he realizado este cambio que yo voy a usar, simplemente lo comparto aquí por si os interesa mergearlo: Poner un link en la parte inferior al la URL que Alfa está mostrando de la web original: item.url.

He borrado los 2 enlaces que habían heredados de pelisalacarta ya que no hacían nada (apuntaban a #, estaría bien que se añadiera uno al GitHub, pero bueno, por ahora los quito, lo podéis editar vosotros para dejarlo a vuestro gusto).

No me convence mucho el texto de "Abrir web original" pero si el PR os interesa lo podéis aceptar y cambiar como os de la gana.

Otra cosa que quería poner, pero no doy con la tecla aun, es que al darle a un torrent/magnet (es decir, algo que se reproduzca con el server torrent) me salga una opción de mostrar o copiar al portapapeles el link original. Creo que lo mejor sería algo que tuviera el link al magnet/torrent y al darle lo abriera directamente. Por ejemplo una entrada de "Enlace al torrent/magent" cuyo href fuera direcatmente el torrent/magnet, así el cliente torrent local entraría en juego. Pero estaría bien que se pudiera copiar el link para poderlo poner en clientes remotos (ej: vía web a un Transmission remoto). Tal vez una doble entrada "Abrir" y "Copiar al portapepeles".

Lo dejo comentado como idea para el que hace la Mediaserver, por si le interesa como futuro cambio.
