### PR TITLE
[mediaserver] No escribir NULL en campos NULL y arreglar autohide de elementos basado en estos campos

### DIFF
--- a/mediaserver/platformcode/template/js/protocol.js
+++ b/mediaserver/platformcode/template/js/protocol.js
@@ -285,6 +285,7 @@ function get_response(data) {
 				else {
 					keypress = "";
 				};
+                if (!data.items[x].value) data.items[x].value = "";
                 itemlist[data.items[x].category].push(replace_list(html.config.text, {
                     "item_color": data.items[x].color,
                     "item_label": data.items[x].label,


### PR DESCRIPTION
Los campos textuales que no tienen valor le llegaban al evaluate() y a lo que añade los elementos con "null". Así que por un lado escribía "null" y por otro siempre se mostraban cosas que debían estar ocultas (ya que comparaba con el string vacío).

Haciendo una pequeña transformación en los campos de texto con NULL a "" las cosas se muestran mejor.