### PR TITLE
[Mediaserver] Arregla el mostrar la config de "Descargas"

### DIFF
--- a/mediaserver/platformcode/controllers/html.py
+++ b/mediaserver/platformcode/controllers/html.py
@@ -677,16 +677,17 @@ class platform(Platformtools):
             if not "label" in c: continue
 
             # Obtenemos el valor
-            if not c["id"] in dict_values:
-                if not callback:
-                    c["value"] = config.get_setting(c["id"], **kwargs)
+            if "id" in c:
+                if not c["id"] in dict_values:
+                    if not callback:
+                        c["value"] = config.get_setting(c["id"], **kwargs)
+                    else:
+                        c["value"] = c["default"]
+
+                    dict_values[c["id"]] = c["value"]
+
                 else:
-                    c["value"] = c["default"]
-
-                dict_values[c["id"]] = c["value"]
-
-            else:
-                c["value"] = dict_values[c["id"]]
+                    c["value"] = dict_values[c["id"]]
 
             # Translation
             if c['label'].startswith('@') and unicode(c['label'][1:]).isnumeric():

--- a/plugin.video.alfa/channels/downloads.json
+++ b/plugin.video.alfa/channels/downloads.json
@@ -24,6 +24,7 @@
   ],
   "settings": [
     {
+      "id": "lab_1",
       "type": "label",
       "label": "Ubicacion de archivos",
       "enabled": true,
@@ -54,6 +55,7 @@
       "visible": true
     },
     {
+      "id": "lab_2",
       "type": "label",
       "label": "Descarga",
       "enabled": true,
@@ -132,6 +134,7 @@
       "visible": true
     },
     {
+      "id": "lab_3",
       "type": "label",
       "label": "Elección del servidor",
       "enabled": true,

--- a/plugin.video.alfa/channels/downloads.json
+++ b/plugin.video.alfa/channels/downloads.json
@@ -24,7 +24,6 @@
   ],
   "settings": [
     {
-      "id": "lab_1",
       "type": "label",
       "label": "Ubicacion de archivos",
       "enabled": true,
@@ -55,7 +54,6 @@
       "visible": true
     },
     {
-      "id": "lab_2",
       "type": "label",
       "label": "Descarga",
       "enabled": true,
@@ -134,7 +132,6 @@
       "visible": true
     },
     {
-      "id": "lab_3",
       "type": "label",
       "label": "Elección del servidor",
       "enabled": true,


### PR DESCRIPTION
En MediaServer petaba al cargar los labels de la config de "Descargas" ya que no tienen ID.
Lo he arreglado primero poniendo id's fake (parece que la videolibrary lo tiene así) pero no tiene sentido que eso sea la solución cuando Kodi no se queja, así que he probado a hacer un check de si "c" tiene ID, y parece que va OK (al menos en las pruebas que he realizado)