### PR TITLE
Recuperar el idioma en el nombre de los episodios en SeriesBlanco

### DIFF
--- a/plugin.video.alfa/channels/seriesblanco.py
+++ b/plugin.video.alfa/channels/seriesblanco.py
@@ -217,7 +217,7 @@ def episodios(item):
         idiomas = " ".join(["[%s]" % IDIOMAS.get(language, "OVOS") for language in
                             re.findall("banderas/([^\.]+)", flags, re.MULTILINE)])
         filter_lang = idiomas.replace("[", "").replace("]", "").split(" ")
-        display_title = "%s - %s" % (item.show, title)
+        display_title = "%s - %s %s" % (item.show, title, idiomas)
         # logger.debug("Episode found %s: %s" % (display_title, urlparse.urljoin(HOST, url)))
         itemlist.append(item.clone(title=display_title, url=urlparse.urljoin(HOST, url),
                                    action="findvideos", plot=plot, fanart=fanart, language=filter_lang))


### PR DESCRIPTION
Por alguna razón se ha quitado el idioma al mostrar los episodios por lo que ahora es imposible saber si algo está en español o en VO mirando la lista de episodios.

Entras, ves "Episodio 6x10 - Episodio 7x01 - Episodio 7x02" y tienes que ir dándole para saber en que está, algo que no tiene sentido cuando antes estaba infinitamente mejor, de un vistazo se puede saber que elementos están en que idioma.

Y no se puede depender de usar filtro de idiomas ya que en una casa puede haber gente que vea cosas en VO y otra que los vea en Español, no van a estar activando y desactivando filtros cuando antes era tan simple como darle a la serie y ver "Episodio 6x10 - Español VOSE | Episodio 7x01 VOSE"

![Ejemplo](https://i.imgur.com/aZxjFys.png)