### PR TITLE
Quitar AutoPlay de plataformas no XBMC + Fix del autoplay no inicializado

### DIFF
--- a/plugin.video.alfa/channels/autoplay.py
+++ b/plugin.video.alfa/channels/autoplay.py
@@ -88,6 +88,9 @@ def start(itemlist, item):
         # Obtiene el nodo AUTOPLAY desde el json
         autoplay_node = jsontools.get_node_from_file('autoplay', 'AUTOPLAY')
 
+    if not item.channel in autoplay_node:
+        return itemlist
+
     # Agrega servidores y calidades que no estaban listados a autoplay_node
     new_options = check_value(item.channel, itemlist)
 

--- a/plugin.video.alfa/channels/autoplay.py
+++ b/plugin.video.alfa/channels/autoplay.py
@@ -43,6 +43,10 @@ def show_option(channel, itemlist, text_color='yellow', thumbnail=None, fanart=N
     :return:
     '''
     logger.info()
+
+    if not config.is_xbmc():
+        return itemlist
+
     if thumbnail == None:
         thumbnail = 'https://s7.postimg.org/65ooga04b/Auto_Play.png'
     if fanart == None:
@@ -74,228 +78,228 @@ def start(itemlist, item):
     :return: intenta autoreproducir, en caso de fallar devuelve el itemlist que recibio en un principio
     '''
     logger.info()
-    global autoplay_node
 
     if not config.is_xbmc():
-        platformtools.dialog_notification('AutoPlay ERROR', 'Sólo disponible para XBMC/Kodi')
+        #platformtools.dialog_notification('AutoPlay ERROR', 'Sólo disponible para XBMC/Kodi')
         return itemlist
-    else:
-        if not autoplay_node:
-            # Obtiene el nodo AUTOPLAY desde el json
-            autoplay_node = jsontools.get_node_from_file('autoplay', 'AUTOPLAY')
 
-        # Agrega servidores y calidades que no estaban listados a autoplay_node
-        new_options = check_value(item.channel, itemlist)
+    global autoplay_node
+    if not autoplay_node:
+        # Obtiene el nodo AUTOPLAY desde el json
+        autoplay_node = jsontools.get_node_from_file('autoplay', 'AUTOPLAY')
 
-        # Obtiene el nodo del canal desde autoplay_node
-        channel_node = autoplay_node.get(item.channel, {})
-        # Obtiene los ajustes des autoplay para este canal
-        settings_node = channel_node.get('settings', {})
+    # Agrega servidores y calidades que no estaban listados a autoplay_node
+    new_options = check_value(item.channel, itemlist)
 
-        if settings_node['active']:
-            url_list_valid = []
-            autoplay_list = []
-            favorite_servers = []
-            favorite_quality = []
+    # Obtiene el nodo del canal desde autoplay_node
+    channel_node = autoplay_node.get(item.channel, {})
+    # Obtiene los ajustes des autoplay para este canal
+    settings_node = channel_node.get('settings', {})
 
-            # Guarda el valor actual de "Accion y Player Mode" en preferencias
-            user_config_setting_action = config.get_setting("default_action")
-            user_config_setting_player = config.get_setting("player_mode")
-            # Habilita la accion "Ver en calidad alta" (si el servidor devuelve más de una calidad p.e. gdrive)
-            if user_config_setting_action != 2:
-                config.set_setting("default_action", 2)
-            if user_config_setting_player != 0:
-                config.set_setting("player_mode", 0)
+    if settings_node['active']:
+        url_list_valid = []
+        autoplay_list = []
+        favorite_servers = []
+        favorite_quality = []
 
-            # Informa que AutoPlay esta activo
-            platformtools.dialog_notification('AutoPlay Activo', '', sound=False)
+        # Guarda el valor actual de "Accion y Player Mode" en preferencias
+        user_config_setting_action = config.get_setting("default_action")
+        user_config_setting_player = config.get_setting("player_mode")
+        # Habilita la accion "Ver en calidad alta" (si el servidor devuelve más de una calidad p.e. gdrive)
+        if user_config_setting_action != 2:
+            config.set_setting("default_action", 2)
+        if user_config_setting_player != 0:
+            config.set_setting("player_mode", 0)
 
-            # Prioridades a la hora de ordenar itemlist:
-            #       0: Servidores y calidades
-            #       1: Calidades y servidores
-            #       2: Solo servidores
-            #       3: Solo calidades
-            #       4: No ordenar
-            if settings_node['custom_servers'] and settings_node['custom_quality']:
-                priority = settings_node['priority']  # 0: Servidores y calidades o 1: Calidades y servidores
-            elif settings_node['custom_servers']:
-                priority = 2  # Solo servidores
-            elif settings_node['custom_quality']:
-                priority = 3  # Solo calidades
-            else:
-                priority = 4  # No ordenar
+        # Informa que AutoPlay esta activo
+        platformtools.dialog_notification('AutoPlay Activo', '', sound=False)
 
-            # Obtiene las listas servidores, calidades disponibles desde el nodo del json de AutoPlay
-            server_list = channel_node.get('servers', [])
-            quality_list = channel_node.get('quality', [])
+        # Prioridades a la hora de ordenar itemlist:
+        #       0: Servidores y calidades
+        #       1: Calidades y servidores
+        #       2: Solo servidores
+        #       3: Solo calidades
+        #       4: No ordenar
+        if settings_node['custom_servers'] and settings_node['custom_quality']:
+            priority = settings_node['priority']  # 0: Servidores y calidades o 1: Calidades y servidores
+        elif settings_node['custom_servers']:
+            priority = 2  # Solo servidores
+        elif settings_node['custom_quality']:
+            priority = 3  # Solo calidades
+        else:
+            priority = 4  # No ordenar
 
-            # Se guardan los textos de cada servidor y calidad en listas p.e. favorite_servers = ['openload',
-            # 'streamcloud']
-            for num in range(1, 4):
-                favorite_servers.append(channel_node['servers'][settings_node['server_%s' % num]])
-                favorite_quality.append(channel_node['quality'][settings_node['quality_%s' % num]])
+        # Obtiene las listas servidores, calidades disponibles desde el nodo del json de AutoPlay
+        server_list = channel_node.get('servers', [])
+        quality_list = channel_node.get('quality', [])
 
-            # Se filtran los enlaces de itemlist y que se correspondan con los valores de autoplay
-            for item in itemlist:
-                autoplay_elem = dict()
+        # Se guardan los textos de cada servidor y calidad en listas p.e. favorite_servers = ['openload',
+        # 'streamcloud']
+        for num in range(1, 4):
+            favorite_servers.append(channel_node['servers'][settings_node['server_%s' % num]])
+            favorite_quality.append(channel_node['quality'][settings_node['quality_%s' % num]])
 
-                # Comprobamos q se trata de un item de video
-                if 'server' not in item:
+        # Se filtran los enlaces de itemlist y que se correspondan con los valores de autoplay
+        for item in itemlist:
+            autoplay_elem = dict()
+
+            # Comprobamos q se trata de un item de video
+            if 'server' not in item:
+                continue
+
+            # Agrega la opcion configurar AutoPlay al menu contextual
+            if 'context' not in item:
+                item.context = list()
+            if not filter(lambda x: x['action'] == 'autoplay_config', context):
+                item.context.append({"title": "Configurar AutoPlay",
+                                     "action": "autoplay_config",
+                                     "channel": "autoplay",
+                                     "from_channel": item.channel})
+
+            # Si no tiene calidad definida le asigna calidad 'default'
+            if item.quality == '':
+                item.quality = 'default'
+
+            # Se crea la lista para configuracion personalizada
+            if priority < 2:  # 0: Servidores y calidades o 1: Calidades y servidores
+
+                # si el servidor y la calidad no se encuentran en las listas de favoritos o la url esta repetida,
+                # descartamos el item
+                if item.server not in favorite_servers or item.quality not in favorite_quality \
+                        or item.url in url_list_valid:
                     continue
-
-                # Agrega la opcion configurar AutoPlay al menu contextual
-                if 'context' not in item:
-                    item.context = list()
-                if not filter(lambda x: x['action'] == 'autoplay_config', context):
-                    item.context.append({"title": "Configurar AutoPlay",
-                                         "action": "autoplay_config",
-                                         "channel": "autoplay",
-                                         "from_channel": item.channel})
-
-                # Si no tiene calidad definida le asigna calidad 'default'
-                if item.quality == '':
-                    item.quality = 'default'
-
-                # Se crea la lista para configuracion personalizada
-                if priority < 2:  # 0: Servidores y calidades o 1: Calidades y servidores
-
-                    # si el servidor y la calidad no se encuentran en las listas de favoritos o la url esta repetida,
-                    # descartamos el item
-                    if item.server not in favorite_servers or item.quality not in favorite_quality \
-                            or item.url in url_list_valid:
-                        continue
-                    autoplay_elem["indice_server"] = favorite_servers.index(item.server)
-                    autoplay_elem["indice_quality"] = favorite_quality.index(item.quality)
-
-                elif priority == 2:  # Solo servidores
-
-                    # si el servidor no se encuentra en la lista de favoritos o la url esta repetida,
-                    # descartamos el item
-                    if item.server not in favorite_servers or item.url in url_list_valid:
-                        continue
-                    autoplay_elem["indice_server"] = favorite_servers.index(item.server)
-
-                elif priority == 3:  # Solo calidades
-
-                    # si la calidad no se encuentra en la lista de favoritos o la url esta repetida,
-                    # descartamos el item
-                    if item.quality not in favorite_quality or item.url in url_list_valid:
-                        continue
-                    autoplay_elem["indice_quality"] = favorite_quality.index(item.quality)
-
-                else:  # No ordenar
-
-                    # si la url esta repetida, descartamos el item
-                    if item.url in url_list_valid:
-                        continue
-
-                # Si el item llega hasta aqui lo añadimos al listado de urls validas y a autoplay_list
-                url_list_valid.append(item.url)
-                autoplay_elem['videoitem'] = item
-                # autoplay_elem['server'] = item.server
-                # autoplay_elem['quality'] = item.quality
-                autoplay_list.append(autoplay_elem)
-
-            # Ordenamos segun la prioridad
-            if priority == 0:  # Servidores y calidades
-                autoplay_list.sort(key=lambda orden: (orden['indice_server'], orden['indice_quality']))
-
-            elif priority == 1:  # Calidades y servidores
-                autoplay_list.sort(key=lambda orden: (orden['indice_quality'], orden['indice_server']))
+                autoplay_elem["indice_server"] = favorite_servers.index(item.server)
+                autoplay_elem["indice_quality"] = favorite_quality.index(item.quality)
 
             elif priority == 2:  # Solo servidores
-                autoplay_list.sort(key=lambda orden: orden['indice_server'])
+
+                # si el servidor no se encuentra en la lista de favoritos o la url esta repetida,
+                # descartamos el item
+                if item.server not in favorite_servers or item.url in url_list_valid:
+                    continue
+                autoplay_elem["indice_server"] = favorite_servers.index(item.server)
 
             elif priority == 3:  # Solo calidades
-                autoplay_list.sort(key=lambda orden: orden['indice_quality'])
 
-            # Si hay elementos en la lista de autoplay se intenta reproducir cada elemento, hasta encontrar uno
-            # funcional o fallen todos
-            if autoplay_list:
-                played = False
-                max_intentos = 5
-                max_intentos_servers = {}
+                # si la calidad no se encuentra en la lista de favoritos o la url esta repetida,
+                # descartamos el item
+                if item.quality not in favorite_quality or item.url in url_list_valid:
+                    continue
+                autoplay_elem["indice_quality"] = favorite_quality.index(item.quality)
 
-                # Si se esta reproduciendo algo detiene la reproduccion
-                if platformtools.is_playing():
-                    platformtools.stop_video()
+            else:  # No ordenar
 
-                for autoplay_elem in autoplay_list:
-                    if not platformtools.is_playing() and not played:
-                        videoitem = autoplay_elem['videoitem']
+                # si la url esta repetida, descartamos el item
+                if item.url in url_list_valid:
+                    continue
 
-                        if videoitem.server not in max_intentos_servers:
+            # Si el item llega hasta aqui lo añadimos al listado de urls validas y a autoplay_list
+            url_list_valid.append(item.url)
+            autoplay_elem['videoitem'] = item
+            # autoplay_elem['server'] = item.server
+            # autoplay_elem['quality'] = item.quality
+            autoplay_list.append(autoplay_elem)
+
+        # Ordenamos segun la prioridad
+        if priority == 0:  # Servidores y calidades
+            autoplay_list.sort(key=lambda orden: (orden['indice_server'], orden['indice_quality']))
+
+        elif priority == 1:  # Calidades y servidores
+            autoplay_list.sort(key=lambda orden: (orden['indice_quality'], orden['indice_server']))
+
+        elif priority == 2:  # Solo servidores
+            autoplay_list.sort(key=lambda orden: orden['indice_server'])
+
+        elif priority == 3:  # Solo calidades
+            autoplay_list.sort(key=lambda orden: orden['indice_quality'])
+
+        # Si hay elementos en la lista de autoplay se intenta reproducir cada elemento, hasta encontrar uno
+        # funcional o fallen todos
+        if autoplay_list:
+            played = False
+            max_intentos = 5
+            max_intentos_servers = {}
+
+            # Si se esta reproduciendo algo detiene la reproduccion
+            if platformtools.is_playing():
+                platformtools.stop_video()
+
+            for autoplay_elem in autoplay_list:
+                if not platformtools.is_playing() and not played:
+                    videoitem = autoplay_elem['videoitem']
+
+                    if videoitem.server not in max_intentos_servers:
+                        max_intentos_servers[videoitem.server] = max_intentos
+
+                    # Si se han alcanzado el numero maximo de intentos de este servidor saltamos al siguiente
+                    if max_intentos_servers[videoitem.server] == 0:
+                        continue
+
+                    lang = " "
+                    if hasattr(videoitem, 'language') and videoitem.language != "":
+                        lang = " '%s' " % videoitem.language
+
+                    platformtools.dialog_notification("AutoPlay", "%s%s%s" % (
+                        videoitem.server.upper(), lang, videoitem.quality.upper()), sound=False)
+                    # TODO videoitem.server es el id del server, pero podria no ser el nombre!!!
+
+                    # Intenta reproducir los enlaces
+                    # Si el canal tiene metodo play propio lo utiliza
+                    channel = __import__('channels.%s' % item.channel, None, None, ["channels.%s" % item.channel])
+                    if hasattr(channel, 'play'):
+                        resolved_item = getattr(channel, 'play')(videoitem)
+                        if len(resolved_item) > 0:
+                            if isinstance(resolved_item[0], list):
+                                videoitem.video_urls = resolved_item
+                            else:
+                                videoitem = resolved_item[0]
+
+                    # si no directamente reproduce
+                    platformtools.play_video(videoitem)
+
+                    try:
+                        if platformtools.is_playing():
+                            played = True
+                            break
+                    except:  # TODO evitar el informe de que el conector fallo o el video no se encuentra
+                        logger.debug(str(len(autoplay_list)))
+
+                    # Si hemos llegado hasta aqui es por q no se ha podido reproducir
+                    max_intentos_servers[videoitem.server] -= 1
+
+                    # Si se han alcanzado el numero maximo de intentos de este servidor
+                    # preguntar si queremos seguir probando o lo ignoramos
+                    if max_intentos_servers[videoitem.server] == 0:
+                        text = "Parece que los enlaces de %s no estan funcionando." % videoitem.server.upper()
+                        if not platformtools.dialog_yesno("AutoPlay", text,
+                                                          "¿Desea ignorar todos los enlaces de este servidor?"):
                             max_intentos_servers[videoitem.server] = max_intentos
 
-                        # Si se han alcanzado el numero maximo de intentos de este servidor saltamos al siguiente
-                        if max_intentos_servers[videoitem.server] == 0:
-                            continue
+        else:
+            platformtools.dialog_notification('AutoPlay No Fue Posible', 'No Hubo Coincidencias')
+        if new_options:
+            platformtools.dialog_notification("AutoPlay", "Nueva Calidad/Servidor disponible en la "
+                                                          "configuracion", sound=False)
 
-                        lang = " "
-                        if hasattr(videoitem, 'language') and videoitem.language != "":
-                            lang = " '%s' " % videoitem.language
+        # Restaura si es necesario el valor previo de "Accion y Player Mode" en preferencias
+        if user_config_setting_action != 2:
+            config.set_setting("default_action", user_config_setting_action)
+        if user_config_setting_player != 0:
+            config.set_setting("player_mode", user_config_setting_player)
 
-                        platformtools.dialog_notification("AutoPlay", "%s%s%s" % (
-                            videoitem.server.upper(), lang, videoitem.quality.upper()), sound=False)
-                        # TODO videoitem.server es el id del server, pero podria no ser el nombre!!!
-
-                        # Intenta reproducir los enlaces
-                        # Si el canal tiene metodo play propio lo utiliza
-                        channel = __import__('channels.%s' % item.channel, None, None, ["channels.%s" % item.channel])
-                        if hasattr(channel, 'play'):
-                            resolved_item = getattr(channel, 'play')(videoitem)
-                            if len(resolved_item) > 0:
-                                if isinstance(resolved_item[0], list):
-                                    videoitem.video_urls = resolved_item
-                                else:
-                                    videoitem = resolved_item[0]
-
-                        # si no directamente reproduce
-                        platformtools.play_video(videoitem)
-
-                        try:
-                            if platformtools.is_playing():
-                                played = True
-                                break
-                        except:  # TODO evitar el informe de que el conector fallo o el video no se encuentra
-                            logger.debug(str(len(autoplay_list)))
-
-                        # Si hemos llegado hasta aqui es por q no se ha podido reproducir
-                        max_intentos_servers[videoitem.server] -= 1
-
-                        # Si se han alcanzado el numero maximo de intentos de este servidor
-                        # preguntar si queremos seguir probando o lo ignoramos
-                        if max_intentos_servers[videoitem.server] == 0:
-                            text = "Parece que los enlaces de %s no estan funcionando." % videoitem.server.upper()
-                            if not platformtools.dialog_yesno("AutoPlay", text,
-                                                              "¿Desea ignorar todos los enlaces de este servidor?"):
-                                max_intentos_servers[videoitem.server] = max_intentos
-
-            else:
-                platformtools.dialog_notification('AutoPlay No Fue Posible', 'No Hubo Coincidencias')
-            if new_options:
-                platformtools.dialog_notification("AutoPlay", "Nueva Calidad/Servidor disponible en la "
-                                                              "configuracion", sound=False)
-
-            # Restaura si es necesario el valor previo de "Accion y Player Mode" en preferencias
-            if user_config_setting_action != 2:
-                config.set_setting("default_action", user_config_setting_action)
-            if user_config_setting_player != 0:
-                config.set_setting("player_mode", user_config_setting_player)
-
-        # devuelve la lista de enlaces para la eleccion manual
-        return itemlist
+    # devuelve la lista de enlaces para la eleccion manual
+    return itemlist
 
 
 def init(channel, list_servers, list_quality):
     '''
-    Comprueba la existencia de canal en el archivo de configuracion de Autoplay y si no existe lo añade. 
+    Comprueba la existencia de canal en el archivo de configuracion de Autoplay y si no existe lo añade.
     Es necesario llamar a esta funcion al entrar a cualquier canal que incluya la funcion Autoplay.
-    
+
     :param channel: (str) id del canal
-    :param list_servers: (list) lista inicial de servidores validos para el canal. No es necesario incluirlos todos, 
+    :param list_servers: (list) lista inicial de servidores validos para el canal. No es necesario incluirlos todos,
         ya que la lista de servidores validos se ira actualizando dinamicamente.
-    :param list_quality: (list) lista inicial de calidades validas para el canal. No es necesario incluirlas todas, 
+    :param list_quality: (list) lista inicial de calidades validas para el canal. No es necesario incluirlas todas,
         ya que la lista de calidades validas se ira actualizando dinamicamente.
     :return: (bool) True si la inicializacion ha sido correcta.
     '''
@@ -304,7 +308,7 @@ def init(channel, list_servers, list_quality):
     result = True
 
     if not config.is_xbmc():
-        platformtools.dialog_notification('AutoPlay ERROR', 'Sólo disponible para XBMC/Kodi')
+        # platformtools.dialog_notification('AutoPlay ERROR', 'Sólo disponible para XBMC/Kodi')
         result = False
     else:
         autoplay_path = os.path.join(config.get_data_path(), "settings_channels", 'autoplay_data.json')
@@ -517,9 +521,9 @@ def autoplay_config(item):
 def save(item, dict_data_saved):
     '''
     Guarda los datos de la ventana de configuracion
-    
+
     :param item: item
-    :param dict_data_saved: dict  
+    :param dict_data_saved: dict
     :return:
     '''
     logger.info()


### PR DESCRIPTION
Se protege el "add_option" para no poner el AutoPlay en plataformas no xbmc.
Se comenta el mensaje de warning porque es un incordio (sale todas y cada una de las veces que hace algo del autoplay)

Edit: Se ha añadido el fix del PR: https://github.com/alfa-addon/addon/pull/87

Arregla el autoplay sin inicializar:

```
[alfa.platformcode.launcher.run] Traceback (most recent call last):
	File ~/.kodi/addons/plugin.video.alfa/platformcode/launcher.py", line 201, in run
	    itemlist = getattr(channel, item.action)(item)
	File "~/.kodi/addons/plugin.video.alfa/channels/seriesblanco.py", line 315, in findvideos
	    autoplay.start(list_links, item)
	File "~/.kodi/addons/plugin.video.alfa/channels/autoplay.py", line 88, in start
	    new_options = check_value(item.channel, itemlist)
	File "~/.kodi/addons/plugin.video.alfa/channels/autoplay.py", line 380, in check_value
	    server_list = channel_node.get('servers')
	AttributeError: 'NoneType' object has no attribute 'get'
```

¿Que es lo que creo que ha pasado?

Ayer se me actualizó el addon con el AutoPlay en seriesblanco, pero a esa hora ya no se tocó Kodi en casa. Así que hoy han ido a Favoritos y le han dado a algún elemento que apunta a SeriesBlanco, le han dado a un episodio... y pum, pete por hacer un get a un None

Lo que creo que pasa es que como han entrado directamente desde favoritos no se ha realizado el autoplay.init() (que se hace al entrar al canal). Así que el json no tenia el canal.

He comprobado que el json tiene una hora un poco más tardía a todos estos petes, cuando he entrado yo manualmente al canal y todo ha empezado a funcionar ya que, ahí, si se había realizado ya el init y el autoplay ya tenía el canal en su json