### PR TITLE
Fix autoplay no inicializado

### DIFF
--- a/plugin.video.alfa/channels/autoplay.py
+++ b/plugin.video.alfa/channels/autoplay.py
@@ -84,6 +84,9 @@ def start(itemlist, item):
             # Obtiene el nodo AUTOPLAY desde el json
             autoplay_node = jsontools.get_node_from_file('autoplay', 'AUTOPLAY')
 
+        if not item.channel in autoplay_node:
+            return itemlist
+
         # Agrega servidores y calidades que no estaban listados a autoplay_node
         new_options = check_value(item.channel, itemlist)
 


### PR DESCRIPTION
Arregla el autoplay sin inicializar:

```
[alfa.platformcode.launcher.run] Traceback (most recent call last):
	File ~/.kodi/addons/plugin.video.alfa/platformcode/launcher.py", line 201, in run
	    itemlist = getattr(channel, item.action)(item)
	File "~/.kodi/addons/plugin.video.alfa/channels/seriesblanco.py", line 315, in findvideos
	    autoplay.start(list_links, item)
	File "~/.kodi/addons/plugin.video.alfa/channels/autoplay.py", line 88, in start
	    new_options = check_value(item.channel, itemlist)
	File "~/.kodi/addons/plugin.video.alfa/channels/autoplay.py", line 380, in check_value
	    server_list = channel_node.get('servers')
	AttributeError: 'NoneType' object has no attribute 'get'
```

¿Que es lo que creo que ha pasado?

Ayer se me actualizó el addon con el AutoPlay en seriesblanco, pero a esa hora ya no se tocó Kodi en casa. Así que hoy han ido a Favoritos y le han dado a algún elemento que apunta a SeriesBlanco, le han dado a un episodio... y pum, pete por hacer un get a un None

Lo que creo que pasa es que como han entrado directamente desde favoritos no se ha realizado el autoplay.init() (que se hace al entrar al canal). Así que el json no tenia el canal.

He comprobado que el json tiene una hora un poco más tardía a todos estos petes, cuando he entrado yo manualmente al canal y todo ha empezado a funcionar ya que, ahí, si se había realizado ya el init y el autoplay ya tenía el canal en su json