### PR TITLE
Arreglar nombres rotos

### DIFF
--- a/plugin.video.alfa/channels/descargas2020.py
+++ b/plugin.video.alfa/channels/descargas2020.py
@@ -91,7 +91,7 @@ def listado(item):
     itemlist = []
     url_next_page =''
 
-    data = re.sub(r"\n|\r|\t|\s{2}|(<!--.*?-->)", "", httptools.downloadpage(item.url).data)
+    data = httptools.downloadpage(item.url).data
     data = unicode(data, "iso-8859-1", errors="replace").encode("utf-8")
     #logger.debug(data)
     logger.debug('item.modo: %s'%item.modo)


### PR DESCRIPTION
Hay títulos que están cortados incluso después del último update. Podéis verlo en estos momentos en la sección "Películas HD", en la segunda página está "los últimos Jed" en vez de Jedi.

He visto que el los replace quitan los espacios haciendo que quede: "Jedigratis" y tras quitarlos se ha arreglado y no veo que nada se rompa, al menos en un primer vistazo. A lo mejor hay algún caso que aun no he visto (igual que supongo que no se vió el caso este de los Jedigratis que acaba en Jed), pero ya digo, he ido dando por algunas secciones y parece seguir funcionado.

Lo pongo en un parche independiente por eso mismo, por si se quiere probar o algo