### PR TITLE
Cambios en Pepecine

### DIFF
--- a/plugin.video.alfa/channels/pepecine.json
+++ b/plugin.video.alfa/channels/pepecine.json
@@ -35,6 +35,24 @@
       "default": true,
       "enabled": true,
       "visible": true
+    },
+    {
+      "id": "filter_languages",
+      "type": "list",
+      "label": "Mostrar enlaces en idioma...",
+      "default": 0,
+      "enabled": true,
+      "visible": true,
+      "lvalues": [
+        "No filtrar",
+        "Español",
+        "Inglés",
+        "Latino",
+        "VO",
+        "VOS",
+        "VOSI",
+        "OVOS"
+      ]
     }
   ]
 }

--- a/plugin.video.alfa/channels/pepecine.json
+++ b/plugin.video.alfa/channels/pepecine.json
@@ -29,14 +29,6 @@
       "visible": true
     },
     {
-      "id": "include_in_newest_infantiles",
-      "type": "bool",
-      "label": "Incluir en Novedades - Infantiles",
-      "default": true,
-      "enabled": true,
-      "visible": true
-    },
-    {
       "id": "include_in_newest_series",
       "type": "bool",
       "label": "Incluir en Novedades - Episodios de series",

--- a/plugin.video.alfa/channels/pepecine.py
+++ b/plugin.video.alfa/channels/pepecine.py
@@ -13,16 +13,13 @@ from core import servertools
 from core import tmdb
 from core.item import Item, InfoLabels
 from platformcode import config, logger
+from channels import filtertools
 
 host = "https://pepecine.io"
 
 IDIOMAS = {'es': 'Español', 'en': 'Inglés', 'la': 'Latino', 'su': 'VOSE', 'vo': 'VO', 'otro': 'OVOS'}
 list_idiomas = IDIOMAS.values()
 list_language = ['default']
-
-CALIDADES = ['SD', 'HDiTunes', 'Micro-HD-720p', 'Micro-HD-1080p', '1080p', '720p']
-list_quality = CALIDADES
-
 
 perpage = 20
 
@@ -68,6 +65,7 @@ def mainlist(item):
                                url    = host + '/donde-ver?q=',
                                action ='search',
                                type   = 'movie'))
+
     return itemlist
 
 
@@ -118,7 +116,7 @@ def search_section(item, data, sectionType):
                              thumbnail = thumbnail,
                              url = url)
         if sectionType == "series":
-            item.show = title;
+            newitem.show = title;
         itemlist.append(newitem)
 
     return itemlist
@@ -288,11 +286,12 @@ def seasons_episodes(item):
     reEpisodes = re.findall("<a[^>]+col-sm-3[^>]+href *= *[\"'](?P<url>[^\"']+).*?<img[^>]+src *= *[\"'](?P<thumbnail>[^\"']+).*?<a[^>]+>(?P<title>.*?)</a>", data, re.MULTILINE | re.DOTALL)
 
     seasons = [item.clone(action = "findvideos",
-                          title = re.sub("<b>Episodio (\d+)</b> - T(\d+) \| {0} \| ".format(item.show), "\g<2>x\g<1> - ", title),
+                          title = re.sub("<b>Episodio (\d+)</b> - T(\d+) \|[^\|]*\| ".format(item.show), "\g<2>x\g<1> - ", title),
                           thumbnail = thumbnail,
                           url = url) for url, thumbnail, title in reEpisodes]
 
     return seasons
+
 
 def findvideos(item):
     logger.info()
@@ -360,7 +359,7 @@ def findvideos(item):
                                            text_color="green",
                                            action="add_pelicula_to_library"
                                      ))
-    return itemlist
+    return filtertools.get_links(itemlist, item, list_idiomas)
 
 
 def play(item):


### PR DESCRIPTION
Estaba mirando canales que hay por aquí y me he encontrado con este que tenía buena pinta pero estaba a medio cocer, y viendo los logs en los últimos meses solo se han cambiado dominios.

Primero me he encontrado con que han cambiado de dominio, así que lo cambié, pero tras hacer el cambio habían algunas cosas que iban y otras que no, pero lo más importante, quería tener soporte a la sección series. Así que se lo he puesto.

He intentado respetar la base que ya había. Por ejemplo, las pelis de la sección "Todas" sigue usando el item.url con el JSON que guarda, pero en series lo borro porque mi PC no puede con ello (y mucho menos mi raspberry). Es infinitamente más rápido borrarlo y procesarlo más tarde que parsear el JSON (se podría quitar también para pelis, pero bueno, ahí no se nota mucho tampoco).

Entonces he arreglado lo que había, puesto sección series, añadido soporte de videoteca para series y he puesto un poco de soporte a filtertools con idiomas (el canal no informa en que idiomas tiene los episodios, solo links).