### PR TITLE
Añadir opción para reducir el item al crear el menú contextual

### DIFF
--- a/plugin.video.alfa/platformcode/platformtools.py
+++ b/plugin.video.alfa/platformcode/platformtools.py
@@ -372,6 +372,44 @@ def set_context_commands(item, parent_item):
     else:
         context = []
 
+    if config.get_setting("faster_item_serialization"):
+        # logger.info("Reducing serialization!")
+        itemBK = item
+        item = Item()
+        item.action = itemBK.action
+        item.channel = itemBK.channel
+        infoLabels = {}
+        if itemBK.infoLabels["year"]:       infoLabels["year"]        = itemBK.infoLabels["year"]
+        if itemBK.infoLabels["imdb_id"]:    infoLabels["imdb_id"]     = itemBK.infoLabels["imdb_id"]
+        if itemBK.infoLabels["tmdb_id"]:    infoLabels["tmdb_id"]     = itemBK.infoLabels["tmdb_id"]
+        if itemBK.infoLabels["tvdb_id"]:    infoLabels["tvdb_id"]     = itemBK.infoLabels["tvdb_id"]
+        if itemBK.infoLabels["noscrap_id"]: infoLabels["noscrap_id"]  = itemBK.infoLabels["noscrap_id"]
+        if len(infoLabels) > 0:             item.infoLabels           = infoLabels
+
+        if itemBK.thumbnail:                item.thumbnail            = itemBK.thumbnail
+        if itemBK.extra:                    item.extra                = itemBK.extra
+        if itemBK.contentEpisodeNumber:     item.contentEpisodeNumber = itemBK.contentEpisodeNumber
+        if itemBK.contentEpisodeTitle:      item.contentEpisodeTitle  = itemBK.contentEpisodeTitle
+        if itemBK.contentPlot:              item.contentPlot          = itemBK.contentPlot
+        if itemBK.contentQuality:           item.contentQuality       = itemBK.contentQuality
+        if itemBK.contentSeason:            item.contentSeason        = itemBK.contentSeason
+        if itemBK.contentSerieName:         item.contentSerieName     = itemBK.contentSerieName
+        if itemBK.contentThumbnail:         item.contentThumbnail     = itemBK.contentThumbnail
+        if itemBK.contentTitle:             item.contentTitle         = itemBK.contentTitle
+        if itemBK.contentType:              item.contentType          = itemBK.contentType
+        if itemBK.duration:                 item.duration             = itemBK.duration
+        if itemBK.fulltitle:                item.fulltitle            = itemBK.fulltitle
+        if itemBK.plot:                     item.plot                 = itemBK.plot
+        if itemBK.quality:                  item.quality              = itemBK.quality
+        if itemBK.show:                     item.show                 = itemBK.show
+        if itemBK.title:                    item.title                = itemBK.title
+        if itemBK.viewcontent:              item.viewcontent          = itemBK.viewcontent
+
+    # itemJson = item.tojson()
+    # logger.info("Elemento: {0} bytes".format(len(itemJson)))
+    # logger.info(itemJson)
+    # logger.info("--------------------------------------------------------------")
+
     # Opciones segun item.context
     for command in context:
         # Predefinidos
@@ -507,14 +545,14 @@ def set_context_commands(item, parent_item):
                                                                       from_action=item.action).tourl())))
 
                 # Descargar episodio
-                if item.contentType == "episode":
+                elif item.contentType == "episode":
                     context_commands.append(("Descargar Episodio", "XBMC.RunPlugin(%s?%s)" %
                                              (sys.argv[0], item.clone(channel="downloads", action="save_download",
                                                                       from_channel=item.channel,
                                                                       from_action=item.action).tourl())))
 
                 # Descargar temporada
-                if item.contentType == "season":
+                elif item.contentType == "season":
                     context_commands.append(("Descargar Temporada", "XBMC.RunPlugin(%s?%s)" %
                                              (sys.argv[0], item.clone(channel="downloads", action="save_download",
                                                                       from_channel=item.channel,

--- a/plugin.video.alfa/resources/language/Spanish/strings.po
+++ b/plugin.video.alfa/resources/language/Spanish/strings.po
@@ -251,6 +251,10 @@ msgctxt "#30164"
 msgid "Delete this file"
 msgstr "Borrar este fichero"
 
+msgctxt "#30300"
+msgid "Faster context menus"
+msgstr "Menús contextuales rápidos (puede causar que algunas opciones no funcionen)"
+
 msgctxt "#30501"
 msgid "Paths"
 msgstr "Rutas"

--- a/plugin.video.alfa/resources/settings.xml
+++ b/plugin.video.alfa/resources/settings.xml
@@ -7,6 +7,7 @@
         <setting id="channel_language" type="labelenum" values="all|cast|lat" label="30019" default="all"/>
         <setting id="trakt_sync" type="bool" label="Sincronizar con Trakt.tv (Debes tener una cuenta)" default="false"/>
         <setting id="forceview" type="bool" label="30043" default="false"/>
+        <setting id="faster_item_serialization" type="bool" label="30300" default="false"/>
         <setting id="debug" type="bool" label="30003" default="false"/>
         <setting label="Uso de servidores" type="lsep"/>
         <setting id="resolve_priority" type="enum" label="Método prioritario" values="Free primero|Premium primero|Debriders primero" default="0"/>


### PR DESCRIPTION
Se añade una opción que permite activar o desactivar (por defecto desactivado) la posibilidad de generar Items con menos elementos en el método de set_context_menu.

Esto genera un speedup considerable (aprox 2x) y parece que no daña mucho las funcionalidades actuales al realizar este filtrado. Por ejemplo, si he visto que había que pasar la fecha de InfoLabels para el InfoPlus, pues lo he añadido después, pero como esto pueden haber otros elementos, de ahí que sea configurable, además, a quien le tarde poco ahora esto no le importará, por lo que preferirá asegurar que el menú contextual funcione bien.

El motivo es que la serialización del item original, con todas las cosas que tienen, es gigantesca y muy costosa. Con 85 series la biblioteca (desde Alfa) cuesta en mi Raspberry 37 segundos en cargar. Al activar esto (se genera un nuevo item con muchas menos cosas) tarda 17. En el sobremesa paso de 5 a 3 segundos.

Había pensado en mover el código a Item y tener un método get_minimal_item() o algo así y que el código en platformtools fuera solo un item = item.get_minimal_item()
Pero bueno, como por ahora es en el único punto que he visto que se tira mucho rato (y que ayuda) lo he dejado donde lo coloqué originalmente.