### PR TITLE
FIX: bug en thumbnails en Unify

### DIFF
--- a/plugin.video.alfa/platformcode/unify.py
+++ b/plugin.video.alfa/platformcode/unify.py
@@ -475,7 +475,9 @@ def thumbnail_type(item):
 
     thumb_type = config.get_setting('video_thumbnail_type')
     info = item.infoLabels
-    item.contentThumbnail = item.thumbnail
+    if not item.contentThumbnail:
+        item.contentThumbnail = item.thumbnail
+
     if info:
         if info['thumbnail'] !='':
             item.contentThumbnail = info['thumbnail']
@@ -488,7 +490,7 @@ def thumbnail_type(item):
                 from core.servertools import get_server_parameters
                 #logger.debug('item.server: %s'%item.server)
                 server_parameters = get_server_parameters(item.server.lower())
-                item.thumbnail = server_parameters.get("thumbnail", "")
+                item.thumbnail = server_parameters.get("thumbnail", item.contentThumbnail)
 
     return item.thumbnail
 


### PR DESCRIPTION
Habia un bug que remplazaba el poster del reproductor por el icono del servidor.
De paso ignoraba la configuracion que decidia si mostrar icono del servidor o no