### PR TITLE
Recuperar lower() en videolibrary, pero configurable

### DIFF
--- a/plugin.video.alfa/channels/videolibrary.json
+++ b/plugin.video.alfa/channels/videolibrary.json
@@ -268,6 +268,16 @@
       ]
     },
     {
+      "id": "lowerize_title",
+      "type": "list",
+      "label": "Crear directorios con letras en miúsculas",
+      "default": 0,
+      "lvalues": [
+        "Si",
+        "No"
+      ]
+    },
+    {
       "id": "lab_1",
       "type": "label",
       "label": "Al añadir contenido, obtener información de:",

--- a/plugin.video.alfa/core/videolibrarytools.py
+++ b/plugin.video.alfa/core/videolibrarytools.py
@@ -125,6 +125,9 @@ def save_movie(item):
 
     base_name = unicode(filetools.validate_path(base_name.replace('/', '-')), "utf8").encode("utf8")
 
+    if config.get_setting("lowerize_title", "videolibrary") == 0:
+        base_name = base_name.lower()
+
     for raiz, subcarpetas, ficheros in filetools.walk(MOVIES_PATH):
         for c in subcarpetas:
             code = scrapertools.find_single_match(c, '\[(.*?)\]')
@@ -245,6 +248,9 @@ def save_tvshow(item, episodelist):
         base_name = item.contentSerieName
 
     base_name = unicode(filetools.validate_path(base_name.replace('/', '-')), "utf8").encode("utf8")
+
+    if config.get_setting("lowerize_title", "videolibrary") == 0:
+        base_name = base_name.lower()
 
     for raiz, subcarpetas, ficheros in filetools.walk(TVSHOWS_PATH):
         for c in subcarpetas:


### PR DESCRIPTION
En un commit alguien decidió que de golpe los directorios no tienen que hacerse un lower() y lo quitó sin más (para que hacerlo configurable).

Sin embargo yo si lo quiero como estaba antes, hace que la carpeta de la videoteca tenga un orden y limpieza "especial", al estar todo en minúsculas. Además, es una carpeta que, por lo general, no debería usarse (tendría que ser solo para Alfa y su videoteca, mis archivos propios deberían ir a otro sitio, en otra fuente de contenidos).

Así he recuperado el comportamiento que había antes, pero he sido más "poilite" y lo he puesto configurable.