### PR TITLE
Inicializar variable

### DIFF
--- a/mediaserver/platformcode/launcher.py
+++ b/mediaserver/platformcode/launcher.py
@@ -40,6 +40,7 @@ def run(item):
                 platformtools.render_items(None, item)
                 return
 
+    channelmodule = None
     # Importa el canal para el item, todo item debe tener un canal, sino sale de la función
     if item.channel:
         channelmodule = import_channel(item)


### PR DESCRIPTION
Por algún motivo ahora se me queja, al darle a Play, de que la linea 106 (hora 107) channelmodule no existe. Y es cierto, tendría que pasar al siguiente (para llamar al método play_video).

Tal vez se me haya actualizado el python o algo así y ahora es más quejica, pero bueno: solo he inicializadola variable previamente y ya me vuelve a funcionar.