### PR TITLE
NewPct1: Agrupa los episodios por Temporadas

### DIFF
--- a/plugin.video.alfa/channels/newpct1.json
+++ b/plugin.video.alfa/channels/newpct1.json
@@ -41,8 +41,8 @@
       "visible": true,
       "lvalues": [
         "Torrentrapid",
-        "Torrentlocura",
         "Tumejortorrent",
+        "Torrentlocura",
         "Tvsinpagar",
         "Descargas2020",
         "Mispelisyseries"        
@@ -52,7 +52,7 @@
       "id": "clonenewpct1_channels_list",
       "type": "text",
       "label": "Lista de clones de NewPct1 y orden de uso",
-      "default": "('1', 'torrentrapid', 'http://torrentrapid.com/', 'movie, tvshow, season, episode', 'serie_episodios'), ('1', 'torrentlocura', 'http://torrentlocura.com/', 'movie, tvshow, season, episode', ''), ('1', 'tumejortorrent', 'http://tumejortorrent.com/', 'movie, tvshow, season, episode', ''), ('1', 'tvsinpagar', 'http://www.tvsinpagar.com/', 'tvshow, season, episode', ''), ('1', 'descargas2020', 'http://descargas2020.com/', 'movie, tvshow, season, episode', ''), ('1', 'mispelisyseries', 'http://mispelisyseries.com/', 'movie', 'search, listado_busqueda')",
+      "default": "('1', 'torrentrapid', 'http://torrentrapid.com/', 'movie, tvshow, season, episode', 'serie_episodios'), ('1', 'tumejortorrent', 'http://tumejortorrent.com/', 'movie, tvshow, season, episode', ''), ('1', 'torrentlocura', 'http://torrentlocura.com/', 'movie, tvshow, season, episode', ''), ('1', 'tvsinpagar', 'http://www.tvsinpagar.com/', 'tvshow, season, episode', ''), ('1', 'descargas2020', 'http://descargas2020.com/', 'movie, tvshow, season, episode', ''), ('1', 'mispelisyseries', 'http://mispelisyseries.com/', 'movie', 'search, listado_busqueda')",
       "enabled": true,
       "visible": false
     },

--- a/plugin.video.alfa/platformcode/platformtools.py
+++ b/plugin.video.alfa/platformcode/platformtools.py
@@ -1047,14 +1047,14 @@ def play_torrent(item, xlistitem, mediaurl):
     # Plugins externos
     if seleccion > 1:
         mediaurl = urllib.quote_plus(item.url)
-        if "quasar" in torrent_options[seleccion][1] and item.infoLabels['tmdb_id']:    #Llamada con más parámetros para completar el título
-            if item.contentType == 'episode':
+        if ("quasar" in torrent_options[seleccion][1] or "elementum" in torrent_options[seleccion][1]) and item.infoLabels['tmdb_id']:    #Llamada con más parámetros para completar el título
+            if item.contentType == 'episode' and "elementum" not in torrent_options[seleccion][1]:
                 mediaurl += "&episode=%s&library=&season=%s&show=%s&tmdb=%s&type=episode" % (item.infoLabels['episode'], item.infoLabels['season'], item.infoLabels['tmdb_id'], item.infoLabels['tmdb_id'])
-            else:
+            elif item.contentType == 'movie':
                 mediaurl += "&library=&tmdb=%s&type=movie" % (item.infoLabels['tmdb_id'])
         xbmc.executebuiltin("PlayMedia(" + torrent_options[seleccion][1] % mediaurl + ")")
         
-        if "quasar" in torrent_options[seleccion][1]:                   #Seleccionamos que clientes torrent soportamos
+        if "quasar" in torrent_options[seleccion][1] or "elementum" in torrent_options[seleccion][1]:   #Seleccionamos que clientes torrent soportamos
             if item.strm_path:                                          #Sólo si es de Videoteca
                 import time
                 time_limit = time.time() + 150                          #Marcamos el timepo máx. de buffering


### PR DESCRIPTION
En el método Episodios se agrupan los episodios por Temporadas, siempre que haya más de una Temporada.

El 99% de código reside el generictools.post_tmdb_seasons

Por diseño de la web, no reperesenta un ahorro de tiempo, solo clarifica el contenido de la pantalla

- Elementum: Soporta el marcado automático de vídeos vistos