### PR TITLE
Videolibrary.list_tvshows: errores aleatorios

### DIFF
--- a/plugin.video.alfa/channels/beeg.py
+++ b/plugin.video.alfa/channels/beeg.py
@@ -53,8 +53,8 @@ def mainlist(item):
     itemlist = []
     itemlist.append(Item(channel=item.channel, action="videos", title="Útimos videos", url=url_api + "/index/main/0/pc",
                          viewmode="movie"))
-    itemlist.append(Item(channel=item.channel, action="listcategorias", title="Listado categorias Populares",
-                         url=url_api + "/index/main/0/pc", extra="popular"))
+    #itemlist.append(Item(channel=item.channel, action="listcategorias", title="Listado categorias Populares",
+    #                     url=url_api + "/index/main/0/pc", extra="popular"))
     itemlist.append(Item(channel=item.channel, action="listcategorias", title="Listado categorias completo",
                          url=url_api + "/index/main/0/pc", extra="nonpopular"))
     itemlist.append(
@@ -74,7 +74,7 @@ def videos(item):
         title = Video["title"]
         itemlist.append(
             Item(channel=item.channel, action="play", title=title, url=url, thumbnail=thumbnail, plot="", show="",
-                 folder=True))
+                 folder=True, contentType="movie"))
 
     # Paginador
     Actual = int(scrapertools.get_match(item.url, url_api + '/index/[^/]+/([0-9]+)/pc'))
@@ -93,10 +93,11 @@ def listcategorias(item):
     data = scrapertools.cache_page(item.url)
     JSONData = json.load(data)
 
-    for Tag in JSONData["tags"][item.extra]:
-        url = url_api + "/index/tag/0/pc?tag=" + Tag
-        title = Tag
-        title = title[:1].upper() + title[1:]
+    #for Tag in JSONData["tags"][item.extra]:
+    for Tag in JSONData["tags"]:
+        url = url_api + "/index/tag/0/pc?tag=" + Tag["tag"]
+        title = '%s - %s' % (str(Tag["tag"]), str(Tag["videos"]))
+        #title = title[:1].upper() + title[1:]
         itemlist.append(
             Item(channel=item.channel, action="videos", title=title, url=url, folder=True, viewmode="movie"))
 
@@ -108,6 +109,7 @@ def search(item, texto):
 
     texto = texto.replace(" ", "+")
     item.url = item.url % (texto)
+    
     try:
         return videos(item)
     # Se captura la excepción, para no interrumpir al buscador global si un canal falla

--- a/plugin.video.alfa/channels/videolibrary.py
+++ b/plugin.video.alfa/channels/videolibrary.py
@@ -127,19 +127,24 @@ def list_tvshows(item):
                     pass
                 
                 head_nfo, item_tvshow = videolibrarytools.read_nfo(tvshow_path)
-                item_tvshow.title = item_tvshow.contentTitle
-                item_tvshow.path = raiz
-                item_tvshow.nfo = tvshow_path
+                try:                                    #A veces da errores aleatorios, por no encontrar el .nfo.  Probablemente problemas de timing
+                    item_tvshow.title = item_tvshow.contentTitle
+                    item_tvshow.path = raiz
+                    item_tvshow.nfo = tvshow_path
 
-                # Menu contextual: Marcar como visto/no visto
-                visto = item_tvshow.library_playcounts.get(item_tvshow.contentTitle, 0)
-                item_tvshow.infoLabels["playcount"] = visto
-                if visto > 0:
-                    texto_visto = config.get_localized_string(60020)
-                    contador = 0
-                else:
-                    texto_visto = config.get_localized_string(60021)
-                    contador = 1
+                    # Menu contextual: Marcar como visto/no visto
+                    visto = item_tvshow.library_playcounts.get(item_tvshow.contentTitle, 0)
+                    item_tvshow.infoLabels["playcount"] = visto
+                    if visto > 0:
+                        texto_visto = config.get_localized_string(60020)
+                        contador = 0
+                    else:
+                        texto_visto = config.get_localized_string(60021)
+                        contador = 1
+                
+                except:
+                    logger.error('No encuentra: ' + str(tvshow_path))
+                    continue
 
                 # Menu contextual: Buscar automáticamente nuevos episodios o no
                 if item_tvshow.active and int(item_tvshow.active) > 0:


### PR DESCRIPTION
A veces da errores aleatorios, por no encontrar el .nfo.  Probablemente problemas de timing

- Beeg: corrección por cambio de estructura