### PR TITLE
Actualizaciones automáticas (quick-fixes)

### DIFF
--- a/plugin.video.alfa/channels/pelispedia.py
+++ b/plugin.video.alfa/channels/pelispedia.py
@@ -143,7 +143,8 @@ def listado_genero(item):
 
     itemlist = []
 
-    data = httptools.downloadpage(item.url).data
+    # ~ data = httptools.downloadpage(item.url).data
+    data = obtener_data(item.url)
     data = re.sub(r"\n|\r|\t|\s{2}|&nbsp;|<Br>|<BR>|<br>|<br/>|<br />|-\s", "", data)
 
     if item.extra == "movies":
@@ -180,7 +181,8 @@ def listado_anio(item):
 
     itemlist = []
 
-    data = httptools.downloadpage(item.url).data
+    # ~ data = httptools.downloadpage(item.url).data
+    data = obtener_data(item.url)
     data = re.sub(r"\n|\r|\t|\s{2}|&nbsp;|<Br>|<BR>|<br>|<br/>|<br />|-\s", "", data)
 
     if item.extra == "movies":

--- a/plugin.video.alfa/channels/setting.py
+++ b/plugin.video.alfa/channels/setting.py
@@ -293,14 +293,21 @@ def submenu_tools(item):
     logger.info()
     itemlist = list()
 
-    #Herramientas de testeo masivo
+    # Herramientas personalizadas
     import os
-    test_path = os.path.join(config.get_runtime_path(), "channels/test.py")
-    if filetools.exists(test_path):
-        itemlist.append(Item(title='Testear canales y servidores ...', channel="test", action="mainlist"))
-        itemlist.append(
-            Item(channel=CHANNELNAME, action="", title="", folder=False, thumbnail=get_thumb("setting_0.png")))
+    channel_custom = os.path.join(config.get_runtime_path(), 'channels', 'custom.py')
+    if not filetools.exists(channel_custom):
+        user_custom = os.path.join(config.get_data_path(), 'custom.py')
+        if filetools.exists(user_custom):
+            filetools.copy(user_custom, channel_custom, silent=True)
+    if filetools.exists(channel_custom):
+        itemlist.append(Item(channel='custom', action='mainlist', title='Custom Channel'))
 
+
+    itemlist.append(Item(channel=CHANNELNAME, action="check_quickfixes", folder=False,
+                         title="Comprobar actualizaciones urgentes", plot="Versión actual: %s" % config.get_addon_version() ))
+    itemlist.append(Item(channel=CHANNELNAME, action="", title="", folder=False,
+                         thumbnail=get_thumb("setting_0.png")))
 
     itemlist.append(Item(channel=CHANNELNAME, title=config.get_localized_string(60564), action="", folder=False,
                          thumbnail=get_thumb("channels.png")))
@@ -320,6 +327,13 @@ def submenu_tools(item):
                              title=config.get_localized_string(60568)))
 
     return itemlist
+
+
+def check_quickfixes(item):
+    logger.info()
+    
+    from platformcode import updater
+    return updater.check_addon_updates(verbose=True)
 
 
 def conf_tools(item):

--- a/plugin.video.alfa/platformcode/config.py
+++ b/plugin.video.alfa/platformcode/config.py
@@ -15,27 +15,26 @@ __settings__ = xbmcaddon.Addon(id="plugin.video." + PLUGIN_NAME)
 __language__ = __settings__.getLocalizedString
 
 
-def get_addon_version(linea_inicio=0, total_lineas=2):
+def get_addon_version(with_fix=True):
     '''
-    Devuelve el número de de versión del addon, obtenido desde el archivo addon.xml
+    Devuelve el número de versión del addon, y opcionalmente número de fix si lo hay
     '''
-    return __settings__.getAddonInfo('version')
-    path = os.path.join(get_runtime_path(), "addon.xml")
-    f = open(path, "rb")
-    data = []
-    for x, line in enumerate(f):
-        if x < linea_inicio: continue
-        if len(data) == total_lineas: break
-        data.append(line)
-    f.close()
-    data1 = "".join(data)
-    # <addon id="plugin.video.alfa" name="Alfa" version="2.5.21" provider-name="Alfa Addon">
-    aux = re.findall('<addon id="plugin.video.alfa" name="Alfa" version="([^"]+)"', data1, re.MULTILINE | re.DOTALL)
-    version = "???"
-    if len(aux) > 0:
-        version = aux[0]
-    return version
+    if with_fix:
+        return __settings__.getAddonInfo('version') + get_addon_version_fix()
+    else:
+        return __settings__.getAddonInfo('version')
 
+def get_addon_version_fix():
+    try:
+        last_fix_json = os.path.join(get_runtime_path(), 'last_fix.json')   # información de la versión fixeada del usuario
+        if os.path.exists(last_fix_json):
+            with open(last_fix_json, 'r') as f: data=f.read(); f.close()
+            fix = re.findall('"fix_version"\s*:\s*(\d+)', data)
+            if fix:
+                return '.fix%s' % fix[0]
+    except:
+        pass
+    return ''
 
 def get_platform(full_version=False):
     """

--- a/plugin.video.alfa/platformcode/updater.py
+++ b/plugin.video.alfa/platformcode/updater.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+# --------------------------------------------------------------------------------
+# Updater (kodi)
+# --------------------------------------------------------------------------------
+
+import os
+import time
+import threading
+
+from platformcode import config, logger, platformtools
+
+from core import httptools
+from core import jsontools
+from core import downloadtools
+from core import ziptools
+from core import filetools
+
+
+def check_addon_init():
+    logger.info()
+    
+    # Subtarea de monitor.  Se activa cada X horas para comprobar si hay FIXES al addon
+    def check_addon_monitor():
+        logger.info()
+        
+        # Obtiene el íntervalo entre actualizaciones y si se quieren mensajes
+        try:
+            timer = int(config.get_setting('addon_update_timer'))               # Intervalo entre actualizaciones, en Ajustes de Alfa
+            if timer <= 0:
+                return                                                          # 0.  No se quieren actualizaciones
+            verbose = config.get_setting('addon_update_message')
+        except:
+            timer = 12                                                          # Por defecto cada 12 horas
+            verbose = False                                                     # Por defecto, sin mensajes
+        timer = timer * 3600                                                    # Lo pasamos a segundos
+
+        if config.get_platform(True)['num_version'] >= 14:                      # Si es Kodi, lanzamos el monitor
+            import xbmc
+            monitor = xbmc.Monitor()
+        else:                                                                   # Lanzamos solo una actualización y salimos
+            check_addon_updates(verbose)                                        # Lanza la actualización
+            return
+            
+        while not monitor.abortRequested():                                     # Loop infinito hasta cancelar Kodi
+
+            check_addon_updates(verbose)                                        # Lanza la actualización
+            
+            if monitor.waitForAbort(timer):                                     # Espera el tiempo programado o hasta que cancele Kodi
+                break                                                           # Cancelación de Kodi, salimos
+                
+        return
+                
+    # Lanzamos en Servicio de actualización de FIXES
+    try:
+        threading.Thread(target=check_addon_monitor).start()                    # Creamos un Thread independiente, hasta el fin de Kodi
+        time.sleep(5)                                                           # Dejamos terminar la primera verificación...
+    except:                                                                     # Si hay problemas de threading, se llama una sola vez
+        try:
+            timer = int(config.get_setting('addon_update_timer'))               # Intervalo entre actualizaciones, en Ajustes de Alfa
+            if timer <= 0:
+                return                                                          # 0.  No se quieren actualizaciones
+            verbose = config.get_setting('addon_update_message')
+        except:
+            verbose = False                                                     # Por defecto, sin mensajes
+            pass
+        check_addon_updates(verbose)                                            # Lanza la actualización, en Ajustes de Alfa
+        time.sleep(5)                                                           # Dejamos terminar la primera verificación...
+            
+    return
+    
+
+def check_addon_updates(verbose=False):
+    logger.info()
+
+    ADDON_UPDATES_JSON = 'http://extra.alfa-addon.com/addon_updates/updates.json'
+    ADDON_UPDATES_ZIP = 'http://extra.alfa-addon.com/addon_updates/updates.zip'
+
+    try:
+        last_fix_json = os.path.join(config.get_runtime_path(), 'last_fix.json')   # información de la versión fixeada del usuario
+        # Se guarda en get_runtime_path en lugar de get_data_path para que se elimine al cambiar de versión
+
+        # Descargar json con las posibles actualizaciones
+        # -----------------------------------------------
+        data = httptools.downloadpage(ADDON_UPDATES_JSON, timeout=2).data
+        if data == '': 
+            logger.info('No se encuentran actualizaciones del addon')
+            if verbose:
+                platformtools.dialog_notification('Alfa ya está actualizado', 'No hay ninguna actualización urgente')
+            return False
+
+        data = jsontools.load(data)
+        if 'addon_version' not in data or 'fix_version' not in data: 
+            logger.info('No hay actualizaciones del addon')
+            if verbose:
+                platformtools.dialog_notification('Alfa ya está actualizado', 'No hay ninguna actualización urgente')
+            return False
+
+        # Comprobar versión que tiene instalada el usuario con versión de la actualización
+        # --------------------------------------------------------------------------------
+        current_version = config.get_addon_version(with_fix=False)
+        if current_version != data['addon_version']:
+            logger.info('No hay actualizaciones para la versión %s del addon' % current_version)
+            if verbose:
+                platformtools.dialog_notification('Alfa ya está actualizado', 'No hay ninguna actualización urgente')
+            return False
+
+        if os.path.exists(last_fix_json):
+            lastfix = jsontools.load(filetools.read(last_fix_json))
+            if lastfix['addon_version'] == data['addon_version'] and lastfix['fix_version'] == data['fix_version']:
+                logger.info('Ya está actualizado con los últimos cambios. Versión %s.fix%d' % (data['addon_version'], data['fix_version']))
+                if verbose:
+                    platformtools.dialog_notification('Alfa ya está actualizado', 'Versión %s.fix%d' % (data['addon_version'], data['fix_version']))
+                return False
+
+        # Descargar zip con las actualizaciones
+        # -------------------------------------
+        localfilename = os.path.join(config.get_data_path(), 'temp_updates.zip')
+        if os.path.exists(localfilename): os.remove(localfilename)
+
+        downloadtools.downloadfile(ADDON_UPDATES_ZIP, localfilename, silent=True)
+        
+        # Descomprimir zip dentro del addon
+        # ---------------------------------
+        unzipper = ziptools.ziptools()
+        unzipper.extract(localfilename, config.get_runtime_path())
+        
+        # Borrar el zip descargado
+        # ------------------------
+        os.remove(localfilename)
+        
+        # Guardar información de la versión fixeada
+        # -----------------------------------------
+        if 'files' in data: data.pop('files', None)
+        filetools.write(last_fix_json, jsontools.dump(data))
+        
+        logger.info('Addon actualizado correctamente a %s.fix%d' % (data['addon_version'], data['fix_version']))
+        if verbose:
+            platformtools.dialog_notification('Alfa actualizado a', 'Versión %s.fix%d' % (data['addon_version'], data['fix_version']))
+        return True
+
+    except:
+        logger.error('Error al comprobar actualizaciones del addon!')
+        if verbose:
+            platformtools.dialog_notification('Alfa actualizaciones', 'Error al comprobar actualizaciones')
+        return False

--- a/plugin.video.alfa/resources/settings.xml
+++ b/plugin.video.alfa/resources/settings.xml
@@ -120,6 +120,11 @@
         <setting type="sep"/>
         <setting label="Para evitar esperar demasiado cuando un servidor no responde:" type="lsep"/>
         <setting id="httptools_timeout" type="labelenum" values="0|5|10|15|20|25|30" label="Timeout (tiempo de espera máximo)" default="15"/>
+        
+        <setting type="sep"/>
+        <setting label="Gestión de actualizaciones urgentes de módulos de Alfa (Quick Fixes):" type="lsep"/>
+        <setting id="addon_update_timer" type="labelenum" values="0|6|12|24" label="Intervalo entre actualizaciones automáticas (horas)" default="12"/>
+        <setting id="addon_update_message" type="bool" label="Quiere ver mensajes de las actualizaciones" default="false"/>
     </category>
 
 </settings>


### PR DESCRIPTION
setting.py : Acceso a custom.py en lugar de test.py. Comprobación manual de quick-fixes.
platformcode/config.py : Mostrar número de fix en get_addon_version.
platformcode/updater.py : Nuevo módulo para gestionar actualizaciones de quick-fixes.
resources/settings.xml : Opciones para controlar las actualizaciones.
channels/pelispedia.py : Corrección al acceder por género y año.
