### PR TITLE
Recuperar el lowerize() que se machacó

### DIFF
--- a/plugin.video.alfa/channels/videolibrary.json
+++ b/plugin.video.alfa/channels/videolibrary.json
@@ -278,6 +278,16 @@
       "visible": true
     },
     {
+      "id": "lowerize_title",
+      "type": "list",
+      "label": "Crear directorios con letras en miúsculas",
+      "default": 0,
+      "lvalues": [
+        "Si",
+        "No"
+      ]
+    },
+    {
       "id": "scraper_movies",
       "type": "list",
       "label": "@60651",


### PR DESCRIPTION
A ver si este dura algo más que el anterior: https://github.com/alfa-addon/addon/commit/73aecca47a5bb7594f0e45dfb76cdb85a6ae2701#diff-43b69953e676913d065bfa994348860b

Porque en 10 días vino uno con un "File Upload" y machacó la configuración