### PR TITLE
Diálogo selección de canales a buscar

### DIFF
--- a/plugin.video.alfa/channels/peliculasgratis.py
+++ b/plugin.video.alfa/channels/peliculasgratis.py
@@ -89,6 +89,7 @@ def search(item, texto):
     logger.info()
     texto = texto.replace(" ", "+")
     item.url = host + "/search/%s" % texto
+    if item.contentType == '': item.contentType = 'movie'
     try:
         return scraper(item)
     # Se captura la excepción, para no interrumpir al buscador global si un canal falla

--- a/plugin.video.alfa/channels/seriecanal.py
+++ b/plugin.video.alfa/channels/seriecanal.py
@@ -9,7 +9,7 @@ from core import servertools
 from platformcode import config, logger
 
 __modo_grafico__ = config.get_setting('modo_grafico', "seriecanal")
-__perfil__ = config.get_setting('perfil', "descargasmix")
+__perfil__ = config.get_setting('perfil', "seriecanal")
 
 # Fijar perfil de color            
 perfil = [['0xFFFFE6CC', '0xFFFFCE9C', '0xFF994D00'],

--- a/plugin.video.alfa/core/tmdb.py
+++ b/plugin.video.alfa/core/tmdb.py
@@ -319,7 +319,7 @@ def set_infoLabels_item(item, seekTmdb=True, idioma_busqueda='es', lock=None):
 
                 __leer_datos(otmdb_global)
 
-            if lock:
+            if lock and lock.locked():
                 lock.release()
 
             if item.infoLabels['episode']:


### PR DESCRIPTION
- search: para kodi >= 17, diálogo para seleccionar canales dónde buscar con multiselect.
- tmdb: añadido and lock.locked() para evitar error con lock.release().
- seriecanal: corregido setting que cogía de otro canal.
- peliculasgratis: asegurar contentType en search para evitar un error posterior.