### PR TITLE
Evitar llamadas a tmdb con todo el itemlist en los findvideos

### DIFF
--- a/plugin.video.alfa/channels/peliculasdk.py
+++ b/plugin.video.alfa/channels/peliculasdk.py
@@ -194,6 +194,8 @@ def peliculas(item):
 def findvideos(item):
     logger.info()
     itemlist = []
+    
+    tmdb.set_infoLabels(item, True) # para refrescar infolabels y obtener más datos en "segunda pasada"
 
     data = httptools.downloadpage(item.url).data
 
@@ -250,8 +252,6 @@ def findvideos(item):
                              thumbnail=item.category,
                              language=idioma, quality=calidad))
                     break
-
-    tmdb.set_infoLabels(itemlist)
 
     itemlist = servertools.get_servers_itemlist(itemlist, lambda i: i.title % i.server.capitalize())
 

--- a/plugin.video.alfa/channels/pepecine.py
+++ b/plugin.video.alfa/channels/pepecine.py
@@ -331,6 +331,8 @@ def seasons_episodes(item):
 def findvideos(item):
     logger.info()
     itemlist=[]
+    
+    tmdb.set_infoLabels(item, True) # para refrescar infolabels y obtener más datos en "segunda pasada"
 
     if item.extra != "links_encoded":
         data = httptools.downloadpage(item.url).data
@@ -366,7 +368,6 @@ def findvideos(item):
         for videoitem in itemlist:
             videoitem.title = '%s [%s] [%s]' % (videoitem.server.capitalize(), videoitem.language, videoitem.quality)
 
-    tmdb.set_infoLabels(itemlist)
     if itemlist and not item.show:
         itemlist.append(Item(channel = item.channel))
         itemlist.append(item.clone(channel="trailertools", title="Buscar Tráiler", action="buscartrailer", context="",

--- a/plugin.video.alfa/channels/tvmoviedb.py
+++ b/plugin.video.alfa/channels/tvmoviedb.py
@@ -1496,7 +1496,7 @@ def detalles_fa(item):
 
     if item.contentType == "tvshow" and ob_tmdb.result:
         itemlist.append(item.clone(action="info_seasons", text_color=color4,
-                                   title=config.get_localized_string(7007) % item.infoLabels["number_of_seasons"]))
+                                   title=config.get_localized_string(70067) % item.infoLabels["number_of_seasons"]))
     if ob_tmdb.result:
         itemlist.append(item.clone(action="reparto", title=config.get_localized_string(70071), text_color=color4,
                                    infoLabels={'tmdb_id': item.infoLabels['tmdb_id'],

--- a/plugin.video.alfa/channels/tvmoviedb.py
+++ b/plugin.video.alfa/channels/tvmoviedb.py
@@ -2457,7 +2457,7 @@ def detalles_mal(item):
 
     # Opción para ver la info de personajes y dobladores/equipo de rodaje
     if not "No characters or voice actors" in data and not "No staff for this anime" in data:
-        itemlist.append(item.clone(action="staff_mal", title=onfig.get_localized_string(70354), text_color=color2,
+        itemlist.append(item.clone(action="staff_mal", title=config.get_localized_string(70354), text_color=color2,
                                    url=item.url + "/characters"))
     if config.is_xbmc():
         item.contextual = True
@@ -2514,7 +2514,7 @@ def detalles_mal(item):
         for url, title in matches:
             new_item = item.clone(infoLabels={'mediatype': item.contentType}, extra="", fanart=default_fan,
                                   thumbnail="")
-            new_item.title = onfig.get_localized_string(70355) % title
+            new_item.title = config.get_localized_string(70355) % title
             new_item.contentTitle = title
             new_item.url = "https://myanimelist.net%s" % url
             itemlist.append(new_item)
@@ -2525,7 +2525,7 @@ def detalles_mal(item):
         for url, title in matches:
             new_item = item.clone(infoLabels={'mediatype': item.contentType}, extra="", fanart=default_fan,
                                   thumbnail="")
-            new_item.title = onfig.get_localized_string(70356) % title
+            new_item.title = config.get_localized_string(70356) % title
             new_item.contentTitle = title
             new_item.url = "https://myanimelist.net%s" % url
             itemlist.append(new_item)
@@ -2536,7 +2536,7 @@ def detalles_mal(item):
         for url, title in matches:
             new_item = item.clone(infoLabels={'mediatype': item.contentType}, extra="", fanart=default_fan,
                                   thumbnail="")
-            new_item.title = onfig.get_localized_string(70357) % title
+            new_item.title = config.get_localized_string(70357) % title
             new_item.contentTitle = title
             new_item.url = "https://myanimelist.net%s" % url
             itemlist.append(new_item)
@@ -2556,12 +2556,12 @@ def detalles_mal(item):
             itemlist.append(new_item)
 
         itemlist.append(
-            item.clone(title=onfig.get_localized_string(70358), action="listado_tmdb", infoLabels={'mediatype': item.contentType},
+            item.clone(title=config.get_localized_string(70358), action="listado_tmdb", infoLabels={'mediatype': item.contentType},
                        search={'url': '%s/%s/recommendations' % (item.extra, item.infoLabels['tmdb_id']),
                                'language': langt, 'page': 1}, text_color=color2))
 
     # Recomendaciones myanimelist y búsqueda de info en anidb (fansubs en español)
-    itemlist.append(item.clone(title=onfig.get_localized_string(70359), action="reco_mal"))
+    itemlist.append(item.clone(title=config.get_localized_string(70359), action="reco_mal"))
     anidb_link = scrapertools.find_single_match(data,
                                                 '<a href="(http://anidb.info/perl-bin/animedb.pl\?show=anime&amp;aid=\d+)')
     if anidb_link:
@@ -2597,7 +2597,7 @@ def videos_mal(item):
 
         next_page = scrapertools.find_single_match(data, '<a href="([^"]+)" class="link-blue-box">More')
         if next_page:
-            itemlist.append(item.clone(title=onfig.get_localized_string(70361), url=next_page, text_color=""))
+            itemlist.append(item.clone(title=config.get_localized_string(70361), url=next_page, text_color=""))
     if itemlist:
         itemlist.insert(0, item.clone(title=config.get_localized_string(70362), action="", text_color=color3))
 
@@ -3142,7 +3142,7 @@ def login_mal(from_list=False):
 
         if not re.search(r'(?i)' + user, response.data):
             logger.error("Error en el login")
-            return False, onfig.get_localized_string(70330), user
+            return False, config.get_localized_string(70330), user
         else:
             if generic:
                 return False, config.get_localized_string(70381), user

--- a/plugin.video.alfa/platformcode/platformtools.py
+++ b/plugin.video.alfa/platformcode/platformtools.py
@@ -110,6 +110,8 @@ def render_items(itemlist, parent_item):
     @type parent_item: item
     @param parent_item: elemento padre
     """
+    logger.info('INICIO render_items')
+
     # Si el itemlist no es un list salimos
     if not type(itemlist) == list:
         return
@@ -284,6 +286,8 @@ def render_items(itemlist, parent_item):
         xbmc.executebuiltin("Container.SetViewMode(%s)" % viewmode_id)
     if parent_item.mode in ['silent', 'get_cached', 'set_cache', 'finish']:
         xbmc.executebuiltin("Container.SetViewMode(500)")
+
+    logger.info('FINAL render_items')
 
 
 def get_viewmode_id(parent_item):

--- a/plugin.video.alfa/resources/language/Spanish/strings.po
+++ b/plugin.video.alfa/resources/language/Spanish/strings.po
@@ -3358,8 +3358,16 @@ msgid "Press to 'Clear cache' saved"
 msgstr "Pulse para 'Borrar caché' guardada"
 
 msgctxt "#70164"
-msgid "Free First|Premium First|Debriders First"
-msgstr "Free primero|Premium primero|Debriders primero"
+msgid "Free First"
+msgstr "Free primero"
+
+msgctxt "#70165"
+msgid "Premium First"
+msgstr "Premium primero"
+
+msgctxt "#70166"
+msgid "Debriders First"
+msgstr "Debriders primero"
 
 msgctxt "#70167"
 msgid "Titles Options"


### PR DESCRIPTION
En algunos canales se llama a tmdb.set_infoLabels(itemlist dentro de findvideos.
Como dentro de findvideos todos los items hacen referencia a la misma película/episodio no hace falta llamar a tmdb para todo el itemlist, y es preferible llamar a tmdb solamente para el item recibido.
En dispositivos poco potentes esto evita que un retardo de varios segundos (por ejemplo con una raspberry pi y una lista de 43 enlaces ralentizaba unos 5/6 segundos, que son muchos).
