### PR TITLE
Cacheo de enlace: nuevos canales y mejoras

### DIFF
--- a/plugin.video.alfa/channels/divxtotal.json
+++ b/plugin.video.alfa/channels/divxtotal.json
@@ -44,6 +44,28 @@
       ]
     },
     {
+      "id": "emergency_urls",
+      "type": "list",
+      "label": "Se quieren guardar Enlaces de Emergencia por si se cae la Web?",
+      "default": 1,
+      "enabled": true,
+      "visible": true,
+      "lvalues": [
+        "No",
+        "Guardar",
+        "Borrar",
+        "Actualizar"
+      ]
+    },
+    {
+      "id": "emergency_urls_torrents",
+      "type": "bool",
+      "label": "Se quieren guardar Torrents de Emergencia por si se cae la Web?",
+      "default": true,
+      "enabled": true,
+      "visible": "!eq(-1,'No')"
+    },
+    {
       "id": "timeout_downloadpage",
       "type": "list",
       "label": "Timeout (segs.) en descarga de páginas o verificación de servidores",

--- a/plugin.video.alfa/channels/elitetorrent.json
+++ b/plugin.video.alfa/channels/elitetorrent.json
@@ -47,6 +47,28 @@
       ]
     },
     {
+      "id": "emergency_urls",
+      "type": "list",
+      "label": "Se quieren guardar Enlaces de Emergencia por si se cae la Web?",
+      "default": 1,
+      "enabled": true,
+      "visible": true,
+      "lvalues": [
+        "No",
+        "Guardar",
+        "Borrar",
+        "Actualizar"
+      ]
+    },
+    {
+      "id": "emergency_urls_torrents",
+      "type": "bool",
+      "label": "Se quieren guardar Torrents de Emergencia por si se cae la Web?",
+      "default": true,
+      "enabled": true,
+      "visible": "!eq(-1,'No')"
+    },
+    {
       "id": "include_in_newest_peliculas",
       "type": "bool",
       "label": "Incluir en Novedades - Peliculas",

--- a/plugin.video.alfa/channels/grantorrent.json
+++ b/plugin.video.alfa/channels/grantorrent.json
@@ -47,6 +47,28 @@
       ]
     },
     {
+      "id": "emergency_urls",
+      "type": "list",
+      "label": "Se quieren guardar Enlaces de Emergencia por si se cae la Web?",
+      "default": 1,
+      "enabled": true,
+      "visible": true,
+      "lvalues": [
+        "No",
+        "Guardar",
+        "Borrar",
+        "Actualizar"
+      ]
+    },
+    {
+      "id": "emergency_urls_torrents",
+      "type": "bool",
+      "label": "Se quieren guardar Torrents de Emergencia por si se cae la Web?",
+      "default": true,
+      "enabled": true,
+      "visible": "!eq(-1,'No')"
+    },
+    {
       "id": "seleccionar_serie_temporada",
       "type": "list",
       "label": "Seleccionar agrupar por Serie o Temporada",

--- a/plugin.video.alfa/channels/newpct1.json
+++ b/plugin.video.alfa/channels/newpct1.json
@@ -63,6 +63,14 @@
       ]
     },
     {
+      "id": "emergency_urls_torrents",
+      "type": "bool",
+      "label": "Se quieren guardar Torrents de Emergencia por si se cae la Web?",
+      "default": true,
+      "enabled": true,
+      "visible": "!eq(-1,'No')"
+    },
+    {
       "id": "clonenewpct1_channel_default",
       "type": "list",
       "label": "Clone de NewPct1 por defecto",
@@ -70,11 +78,11 @@
       "enabled": true,
       "visible": true,
       "lvalues": [
-        "Torrentrapid",
-        "Tumejortorrent",
         "Torrentlocura",
         "Tvsinpagar",
         "Planetatorrent",
+        "Torrentrapid",
+        "Tumejortorrent",
         "Descargas2020",
         "Mispelisyseries"        
       ]
@@ -83,7 +91,7 @@
       "id": "clonenewpct1_channels_list",
       "type": "text",
       "label": "Lista de clones de NewPct1 y orden de uso",
-      "default": "('1', 'torrentrapid', 'http://torrentrapid.com/', 'movie, tvshow, season, episode', 'serie_episodios'), ('1', 'tumejortorrent', 'http://tumejortorrent.com/', 'movie, tvshow, season, episode', ''), ('1', 'torrentlocura', 'http://torrentlocura.com/', 'movie, tvshow, season, episode', ''), ('1', 'tvsinpagar', 'http://www.tvsinpagar.com/', 'tvshow, season, episode', ''), ('1', 'planetatorrent', 'http://planetatorrent.com/', 'movie, tvshow, season, episode', ''), ('1', 'descargas2020', 'http://descargas2020.com/', 'movie, tvshow, season, episode', ''), ('1', 'mispelisyseries', 'http://mispelisyseries.com/', 'movie', 'search, listado_busqueda')",
+      "default": "('1', 'torrentlocura', 'http://torrentlocura.com/', 'movie, tvshow, season, episode', ''), ('1', 'tvsinpagar', 'http://www.tvsinpagar.com/', 'tvshow, season, episode', ''), ('1', 'planetatorrent', 'http://planetatorrent.com/', 'movie, tvshow, season, episode', ''), ('1', 'torrentrapid', 'http://torrentrapid.com/', 'movie, tvshow, season, episode', 'serie_episodios'), ('1', 'tumejortorrent', 'http://tumejortorrent.com/', 'movie, tvshow, season, episode', ''), ('1', 'descargas2020', 'http://descargas2020.com/', 'movie, tvshow, season, episode', ''), ('1', 'mispelisyseries', 'http://mispelisyseries.com/', 'movie', 'search, listado_busqueda')",
       "enabled": true,
       "visible": false
     },

--- a/plugin.video.alfa/channels/videolibrary.py
+++ b/plugin.video.alfa/channels/videolibrary.py
@@ -55,8 +55,11 @@ def list_movies(item, silent=False):
                 new_item.path = raiz
                 new_item.thumbnail = new_item.contentThumbnail
                 new_item.text_color = "blue"
+                strm_path = new_item.strm_path.replace("\\", "/").rstrip("/")
+                if '/' in new_item.path:
+                    new_item.strm_path = strm_path
 
-                if not filetools.exists(filetools.join(new_item.path, filetools.basename(new_item.strm_path))):
+                if not filetools.exists(filetools.join(new_item.path, filetools.basename(strm_path))):
                     # Si se ha eliminado el strm desde la bilbioteca de kodi, no mostrarlo
                     continue
 

--- a/plugin.video.alfa/videolibrary_service.py
+++ b/plugin.video.alfa/videolibrary_service.py
@@ -17,6 +17,7 @@ def update(path, p_dialog, i, t, serie, overwrite):
     insertados_total = 0
       
     head_nfo, it = videolibrarytools.read_nfo(path + '/tvshow.nfo')
+    category = serie.category
 
     # logger.debug("%s: %s" %(serie.contentSerieName,str(list_canales) ))
     for channel, url in serie.library_urls.items():
@@ -28,6 +29,7 @@ def update(path, p_dialog, i, t, serie, overwrite):
             head_nfo, it = videolibrarytools.read_nfo(path + '/tvshow.nfo')         #Refresca el .nfo para recoger actualizaciones
             if it.emergency_urls:
                 serie.emergency_urls = it.emergency_urls
+            serie.category = category
             serie, it, overwrite = generictools.redirect_clone_newpct1(serie, head_nfo, it, path, overwrite)
         except:
             pass


### PR DESCRIPTION
**Cacheo de enlaces**:
- Mejores controles para el cacheo de enlaces para el contenido existiente en la Videoteca.
- Opción para cachear los archivos .torrent y almacenarlos en la Videoteca
- Mejoras en el "play" de enlaces torrent: ahora descarga siempre los .torrent en local y pasa al cliente Torrent el .torret descargado
- Usando la técnica anterior, permite al canal usar un enlace Torrent alternativo por si el enlace torrent principal no está activo.  El "play" de enlaces torrent seleciona automáticamente el .torrent alternativo si el principal no funciona.

**Nuevos canales añadidos al cacheo de enlaces**:
- DivxTotal
- EliteTorrent
- GranTorrent

**Mejorados**:
- Newpct1 (mejorada la Alta Disponibilidad en Findvideos)