### PR TITLE
Alternativa a ziptools/zipfile

### DIFF
--- a/plugin.video.alfa/platformcode/updater.py
+++ b/plugin.video.alfa/platformcode/updater.py
@@ -122,8 +122,13 @@ def check_addon_updates(verbose=False):
         
         # Descomprimir zip dentro del addon
         # ---------------------------------
-        unzipper = ziptools.ziptools()
-        unzipper.extract(localfilename, config.get_runtime_path())
+        try:
+            unzipper = ziptools.ziptools()
+            unzipper.extract(localfilename, config.get_runtime_path())
+        except:
+            import xbmc
+            xbmc.executebuiltin('XBMC.Extract("%s", "%s")' % (localfilename, config.get_runtime_path()))
+            time.sleep(1)
         
         # Borrar el zip descargado
         # ------------------------


### PR DESCRIPTION
Con Android+Kodi18 en algunos casos la librería zipfile da error. Añadida alternativa con xbmc.extract