### PR TITLE
fix página siguiente

### DIFF
--- a/plugin.video.alfa/channels/jkanime.py
+++ b/plugin.video.alfa/channels/jkanime.py
@@ -108,8 +108,8 @@ def series(item):
                  plot=scrapedplot, show=scrapedtitle))
     tmdb.set_infoLabels(itemlist)
     try:
-        siguiente = scrapertools.find_single_match(data, '<a class="listsiguiente" href="([^"]+)" >Resultados Siguientes')
-        scrapedurl = item.url + siguiente
+        siguiente = scrapertools.find_single_match(data, '<a class="text nav-next" href="([^"]+)"')
+        scrapedurl = siguiente
         scrapedtitle = ">> Pagina Siguiente"
         scrapedthumbnail = ""
         scrapedplot = ""


### PR DESCRIPTION
fixed página siguiente para
-listado alfabetico 
-listado por genero

Antes en listado alfabetico se repetia la url + url de la página siguiente por lo que no mostraba la página siguiente.
(not working) scrapedurl = item.url + siguiente
(fixed) scrapedurl = siguiente 
Antes en listado por genero no mostraba la página siguiente por cambios en la web
(fixed) <a class="text nav-next" href="([^"]+)"
(not working) <a class="listsiguiente" href="([^"]+)" >Resultados Siguientes