### PR TITLE
Mejoras internas

### DIFF
--- a/plugin.video.alfa/channels/grantorrent.json
+++ b/plugin.video.alfa/channels/grantorrent.json
@@ -92,7 +92,7 @@
       "id": "timeout_downloadpage",
       "type": "list",
       "label": "Timeout (segs.) en descarga de páginas o verificación de servidores",
-      "default": 10,
+      "default": 15,
       "enabled": true,
       "visible": true,
       "lvalues": [
@@ -106,7 +106,12 @@
         "7",
         "8",
         "9",
-        "10"
+        "10",
+        "11",
+        "12",
+        "13",
+        "14",
+        "15"
       ]
     }
   ]

--- a/plugin.video.alfa/channels/grantorrent.py
+++ b/plugin.video.alfa/channels/grantorrent.py
@@ -30,7 +30,7 @@ channel = "grantorrent"
 dict_url_seasons = dict()
 __modo_grafico__ = config.get_setting('modo_grafico', channel)
 timeout = config.get_setting('timeout_downloadpage', channel)
-if timeout <= 5: timeout = timeout*2
+if timeout > 0 and timeout <= 10: timeout = 15
 modo_serie_temp = config.get_setting('seleccionar_serie_temporada', channel)
 modo_ultima_temp = config.get_setting('seleccionar_ult_temporadda_activa', channel)
 
@@ -82,7 +82,7 @@ def submenu(item):
     
     data = ''
     try:
-        data = re.sub(r"\n|\r|\t|\s{2}|(<!--.*?-->)", "", httptools.downloadpage(item.url).data)
+        data = re.sub(r"\n|\r|\t|\s{2}|(<!--.*?-->)", "", httptools.downloadpage(item.url, timeout=timeout).data)
     except:
         pass
         
@@ -157,7 +157,7 @@ def listado(item):
     timeout_search = timeout                # Timeout para descargas
     if item.action == 'search':
         timeout_search = int(timeout * 1.5) # Timeout un poco más largo para las búsquedas
-        if timeout_search < 10:
+        if timeout_search > 0 and timeout_search < 10:
             timeout_search = 10             # Timeout un poco más largo para las búsquedas
     
     #Máximo num. de líneas permitidas por TMDB (40). Máx de 5 páginas por Itemlist para no degradar el rendimiento.  

--- a/plugin.video.alfa/channels/subtorrents.py
+++ b/plugin.video.alfa/channels/subtorrents.py
@@ -591,7 +591,8 @@ def play(item):                                                                 
             os.mkdir(os.path.join(config.get_setting("videolibrarypath"), "subtitles"))
         subtitles = []
         subtitles.extend(item.subtitle)
-        item.subtitle = subtitles[0]                                            #ponemos por defecto el primero
+        item.subtitle = subtitles[0]                                            #ponemos por defecto el primeroç
+        #item.subtitle = os.path.join(config.get_setting("videolibrarypath"), os.path.join("subtitles", scrapertools.find_single_match(subtitles[0], '\/\d{2}\/(.*?\.\w+)$')))
         for subtitle in subtitles:                                              #recorremos la lista
             subtitle_name = scrapertools.find_single_match(subtitle, '\/\d{2}\/(.*?\.\w+)$')                #se pone el nombre del Sub-título
             subtitle_folder_path = os.path.join(config.get_setting("videolibrarypath"), "subtitles", subtitle_name)         #Path de descarga

--- a/plugin.video.alfa/channels/todopeliculas.py
+++ b/plugin.video.alfa/channels/todopeliculas.py
@@ -163,7 +163,7 @@ def listado(item):
             patron = '<div class="blogitem "><a title="([^"]+)"\s+href="([^"]+)">.*?src="([^"]+)" onload'
             
         matches = re.compile(patron, re.DOTALL).findall(data)
-        if not matches and not 'Total: 0 resultados encontrados' in data:           #error
+        if not matches and not 'Total: 0 resultados encontrados' in data and not 'Total: 0 results found' in data:
             item = generictools.web_intervenida(item, data)                         #Verificamos que no haya sido clausurada
             if item.intervencion:                                                   #Sí ha sido clausurada judicialmente
                 item, itemlist = generictools.post_tmdb_episodios(item, itemlist)   #Llamamos al método para el pintado del error

--- a/plugin.video.alfa/core/httptools.py
+++ b/plugin.video.alfa/core/httptools.py
@@ -162,6 +162,7 @@ def downloadpage(url, post=None, headers=None, timeout=None, follow_redirects=Tr
 
     # Limitar tiempo de descarga si no se ha pasado timeout y hay un valor establecido en la variable global
     if timeout is None and HTTPTOOLS_DEFAULT_DOWNLOAD_TIMEOUT is not None: timeout = HTTPTOOLS_DEFAULT_DOWNLOAD_TIMEOUT
+    if timeout == 0: timeout = None
 
     logger.info("----------------------------------------------")
     logger.info("downloadpage Alfa: %s" %__version)

--- a/plugin.video.alfa/platformcode/platformtools.py
+++ b/plugin.video.alfa/platformcode/platformtools.py
@@ -1169,7 +1169,10 @@ def play_torrent(item, xlistitem, mediaurl):
             time.sleep(5)                                       #Repetimos cada intervalo
             #logger.debug(str(time_limit))
         if item.subtitle != '':
+            time.sleep(5)
             xbmc_player.setSubtitles(item.subtitle)
+            #subt = xbmcgui.ListItem(path=item.url, thumbnailImage=item.thumbnail)
+            #subt.setSubtitles([item.subtitle])
 
         if item.strm_path and is_playing():                     #Sólo si es de Videoteca
             from platformcode import xbmc_videolibrary


### PR DESCRIPTION
- GranTorrent: aumento de timeout
- Todopeliculas: detección cuando no hay resultados en una búsqueda
- Httptools: si timeout=0, asumir timeout=None
- Platformtools: Sleep 5 antes de llamar a subtítulos