### PR TITLE
some improvements in core and an option to enable autoplay in any supported channel

### DIFF
--- a/plugin.video.alfa/channels/autoplay.py
+++ b/plugin.video.alfa/channels/autoplay.py
@@ -9,6 +9,7 @@ from platformcode import config, logger
 from platformcode import platformtools
 from platformcode import launcher
 from time import sleep
+from platformcode.config import get_setting
 
 __channel__ = "autoplay"
 
@@ -117,7 +118,7 @@ def start(itemlist, item):
     # Obtiene los ajustes des autoplay para este canal
     settings_node = channel_node.get('settings', {})
 
-    if settings_node['active']:
+    if get_setting('autoplay') or settings_node['active']:
         url_list_valid = []
         autoplay_list = []
         autoplay_b = []
@@ -142,7 +143,7 @@ def start(itemlist, item):
         #       2: Solo servidores
         #       3: Solo calidades
         #       4: No ordenar
-        if settings_node['custom_servers'] and settings_node['custom_quality']:
+        if (settings_node['custom_servers'] and settings_node['custom_quality']) or get_setting('autoplay'):
             priority = settings_node['priority']  # 0: Servidores y calidades o 1: Calidades y servidores
         elif settings_node['custom_servers']:
             priority = 2  # Solo servidores
@@ -391,14 +392,15 @@ def init(channel, list_servers, list_quality, reset=False):
             # Se comprueba que no haya calidades ni servidores duplicados
             if 'default' not in list_quality:
                 list_quality.append('default')
-            list_servers = list(set(list_servers))
-            list_quality = list(set(list_quality))
+            # list_servers = list(set(list_servers))
+            # list_quality = list(set(list_quality))
 
             # Creamos el nodo del canal y lo añadimos
             channel_node = {"servers": list_servers,
                             "quality": list_quality,
                             "settings": {
                                 "active": False,
+                                "plan_b": True,
                                 "custom_servers": False,
                                 "custom_quality": False,
                                 "priority": 0}}
@@ -455,7 +457,7 @@ def check_value(channel, itemlist):
 
     for item in itemlist:
         if item.server.lower() not in server_list and item.server !='':
-            server_list.append(item.server)
+            server_list.append(item.server.lower())
             change = True
         if item.quality not in quality_list and item.quality !='':
             quality_list.append(item.quality)
@@ -672,7 +674,7 @@ def is_active(channel):
     # Obtiene los ajustes des autoplay para este canal
     settings_node = channel_node.get('settings', {})
 
-    return settings_node.get('active', False)
+    return settings_node.get('active', False) or get_setting('autoplay')
 
 
 def reset(item, dict):

--- a/plugin.video.alfa/lib/unshortenit.py
+++ b/plugin.video.alfa/lib/unshortenit.py
@@ -26,7 +26,7 @@ def find_in_text(regex, text, flags=re.IGNORECASE | re.DOTALL):
 
 
 class UnshortenIt(object):
-    _adfly_regex = r'adf\.ly|j\.gs|q\.gs|u\.bb|ay\.gy|atominik\.com|tinyium\.com|microify\.com|threadsphere\.bid|clearload\.bid|activetect\.net|swiftviz\.net|briskgram\.net|activetect\.net|baymaleti\.net|thouth\.net'
+    _adfly_regex = r'adf\.ly|j\.gs|q\.gs|u\.bb|ay\.gy|atominik\.com|tinyium\.com|microify\.com|threadsphere\.bid|clearload\.bid|activetect\.net|swiftviz\.net|briskgram\.net|activetect\.net|baymaleti\.net|thouth\.net|uclaut.net'
     _linkbucks_regex = r'linkbucks\.com|any\.gs|cash4links\.co|cash4files\.co|dyo\.gs|filesonthe\.net|goneviral\.com|megaline\.co|miniurls\.co|qqc\.co|seriousdeals\.net|theseblogs\.com|theseforums\.com|tinylinks\.co|tubeviral\.com|ultrafiles\.net|urlbeat\.net|whackyvidz\.com|yyv\.co'
     _adfocus_regex = r'adfoc\.us'
     _lnxlu_regex = r'lnx\.lu'
@@ -76,7 +76,7 @@ class UnshortenIt(object):
         if re.search(self._cryptmango_regex, uri, re.IGNORECASE):
             return self._unshorten_cryptmango(uri)
 
-        return uri, 200
+        return uri, 0
 
     def unwrap_30x(self, uri, timeout=10):
         def unwrap_30x(uri, timeout=10):
@@ -442,12 +442,15 @@ class UnshortenIt(object):
             r = httptools.downloadpage(uri, timeout=self._timeout, cookies=False)
             html = r.data
 
-            uri = re.findall(r'<a class="push_button blue" href=([^>]+)>', html)[0]
+            if 'embed' in uri:
+                uri = re.findall(r'<a class="play-btn" href=([^">]*)>', html)[0]
+            else:
+                uri = re.findall(r'<a class="push_button blue" href=([^>]+)>', html)[0]
 
             return uri, r.code
 
         except Exception as e:
-            return uri, str(e)
+            return uri, 0
 
     def _unshorten_cryptmango(self, uri):
         try:

--- a/plugin.video.alfa/platformcode/platformtools.py
+++ b/plugin.video.alfa/platformcode/platformtools.py
@@ -19,7 +19,7 @@ import xbmcplugin
 from channelselector import get_thumb
 from platformcode import unify
 from core import channeltools
-from core import trakt_tools
+from core import trakt_tools, scrapertoolsV2
 from core.item import Item
 from platformcode import logger
 
@@ -739,13 +739,51 @@ def get_seleccion(default_action, opciones, seleccion, video_urls):
         seleccion = dialog_select(config.get_localized_string(30163), opciones)
     # Ver en calidad baja
     elif default_action == 1:
-        seleccion = 0
+        resolutions = []
+        for url in video_urls:
+            res = calcResolution(url[0])
+            if res:
+                resolutions.append(res)
+        if resolutions:
+            seleccion = resolutions.index(min(resolutions))
+        else:
+            seleccion = 0
     # Ver en alta calidad
     elif default_action == 2:
-        seleccion = len(video_urls) - 1
+        resolutions = []
+        for url in video_urls:
+            res = calcResolution(url[0])
+            if res:
+                resolutions.append(res)
+        if resolutions:
+            seleccion = resolutions.index(max(resolutions))
+        else:
+            seleccion = len(video_urls) - 1
     else:
         seleccion = 0
     return seleccion
+
+
+def calcResolution(option):
+    match = scrapertoolsV2.find_single_match(option, '([0-9]{2,4})x([0-9]{2,4})')
+    resolution = False
+    if match:
+        resolution = int(match[0])*int(match[1])
+    else:
+        if '240p' in option:
+            resolution = 320 * 240
+        elif '360p' in option:
+            resolution = 480 * 360
+        elif ('480p' in option) or ('480i' in option):
+            resolution = 720 * 480
+        elif ('576p' in option) or ('576p' in option):
+            resolution = 720 * 576
+        elif ('720p' in option) or ('HD' in option):
+            resolution = 1280 * 720
+        elif ('1080p' in option) or ('1080i' in option) or ('Full HD' in option):
+            resolution = 1920 * 1080
+
+    return resolution
 
 
 def show_channel_settings(**kwargs):

--- a/plugin.video.alfa/resources/language/English/strings.po
+++ b/plugin.video.alfa/resources/language/English/strings.po
@@ -4931,3 +4931,6 @@ msgctxt "#70561"
 msgid "Search Similar
 msgstr ""
 
+msgctxt "#70562"
+msgid "autoplay"
+msgstr "Enable autoplay in all channels"

--- a/plugin.video.alfa/resources/language/Italian/strings.po
+++ b/plugin.video.alfa/resources/language/Italian/strings.po
@@ -4920,3 +4920,6 @@ msgid "Search Similar
 msgstr "Cerca Simili"
 
 
+msgctxt "#70562"
+msgid "autoplay"
+msgstr "Abilita autoplay in tutti i canali"

--- a/plugin.video.alfa/resources/language/Spanish/strings.po
+++ b/plugin.video.alfa/resources/language/Spanish/strings.po
@@ -4931,7 +4931,9 @@ msgctxt "#70561"
 msgid "Search Similar"
 msgstr "Buscar Similares"
 
-
+msgctxt "#70562"
+msgid "autoplay"
+msgstr "Habilitar reproducción automática en todos los canales"
 
 
 

--- a/plugin.video.alfa/resources/settings.xml
+++ b/plugin.video.alfa/resources/settings.xml
@@ -3,6 +3,7 @@
     <category label="70168">
         <setting id="player_mode" type="enum" values="Direct|SetResolvedUrl|Built-In|Download and Play" label="30044" default="0"/>
         <setting id="default_action" type="enum" lvalues="30006|30007|30008" label="30005" default="0"/>
+        <setting id="autoplay" type="bool" label="70562" default="false" visible="true"/>
         <setting id="thumbnail_type" type="enum" lvalues="30011|30012|30200" label="30010" default="2"/>
         <setting id="channel_language" type="labelenum" values="all|cast|lat" label="30019" default="all"/>
         <setting id="trakt_sync" type="bool" label="70109" default="false"/>

--- a/plugin.video.alfa/servers/decrypters/expurl.py
+++ b/plugin.video.alfa/servers/decrypters/expurl.py
@@ -1,23 +1,14 @@
 # -*- coding: utf-8 -*-
 
-import urlparse
-
 from lib import unshortenit
-
-SERVICES_SHORT = ["adf.ly", "sh.st", "bit.ly", "ul.to"]
-
 
 def expand_url(url):
     e = unshortenit.UnshortenIt()
+    estado = 200
 
-    while Es_Corto(url):
+    while estado != 0:
         long_url, estado = e.unshorten(url)
         url = long_url
 
     return long_url
 
-
-def Es_Corto(url):
-    server = urlparse.urlsplit(url).netloc
-    Corto = (server in SERVICES_SHORT)
-    return Corto


### PR DESCRIPTION
1) "add option to enable autoplay in all channels, plan_b true by default"
This will add an option in settings (default disabled) that force enable autoplay in every supported channel (it's like to go in every channel and enabling autoplay and plan_b, but these settings will not be enabled, only ignored).
Custom quality and servers are still supported, you could go in channel autoplay settings, enable autoplay and choose.
After enabling, you need to do a global search twice to enable every channel (that's because how autoplay save data in autoplay_data.json), i'm not able to fix this.

2) "a better way to detect max and min resolutions"
Now, when you choose "watch in high quality", the last source is selected and if "low quality" the first.
But this is not always true, this commit will add a way to detect max and min resolution, presented in these formats:
-"1920x1080", "640x480" ecc..
-"720p", "1080p" ecc..

3) "add rapidcrypt embedded support and uclaut.net(adf.ly)" and "
do not limit expurl on some services"
These commit improves unshortner services support