### PR TITLE
Launcher: evita bloqueo en Kodi en "Ajuste de tasa refresco de pantalla"

### DIFF
--- a/plugin.video.alfa/channels/mejortorrent.json
+++ b/plugin.video.alfa/channels/mejortorrent.json
@@ -18,7 +18,7 @@
       "id": "domain_name",
       "type": "text",
       "label": "URL actual de la Web Mejor Torrent",
-      "default": "http://www.mejortorrent.org/",
+      "default": "http://www.mejortorrent.tv/",
       "enabled": true,
       "visible": true
     },

--- a/plugin.video.alfa/channels/newpct1.py
+++ b/plugin.video.alfa/channels/newpct1.py
@@ -7,6 +7,7 @@ import urlparse
 import datetime
 import ast
 import random
+import traceback
 
 from channelselector import get_thumb
 from core import httptools
@@ -700,8 +701,12 @@ def listado(item):
         
         #Guardamos el resto de variables del vídeo
         item_local.url = scrapedurl
+        if not item_local.url.startswith("http"):                           #Si le falta el http.: lo ponemos
+            item_local.url = scrapertools.find_single_match(item_local.channel_host, '(\w+:)//') + item_local.url
         item_local.thumbnail = scrapedthumbnail
-        item_local.contentThumbnail = scrapedthumbnail
+        if not item_local.thumbnail.startswith("http"):                     #Si le falta el http.: lo ponemos
+            item_local.thumbnail = scrapertools.find_single_match(item_local.channel_host, '(\w+:)//') + item_local.thumbnail
+        item_local.contentThumbnail = item_local.thumbnail
 
         #Guardamos el año que puede venir en la url, por si luego no hay resultados desde TMDB
         year = ''
@@ -1008,7 +1013,7 @@ def listado_busqueda(item):
             if not data_serie:                                                  #Si no ha logrado encontrar nada, salimos
                 title_subs += ["ERR"]
             
-            elif item_local.channel_alt:                                                    #Si ha habido fail-over, lo comento
+            elif item_local.channel_alt:                                        #Si ha habido fail-over, lo comento
                 url = url.replace(item_local.channel_alt, item_local.category.lower())
                 title_subs += ["ALT"]
 
@@ -1029,8 +1034,10 @@ def listado_busqueda(item):
                     title_subs += ["Episodio %sx%s" % (scrapertools.find_single_match(url, '\/temp.*?-(\d+)-?\/cap.*?-(\d+(?:-al-\d+)?)-?\/'))]
                     url = item_local.url
             except:
-                pass
+                logger.error(traceback.format_exc())
                 
+            #logger.debug(item_local.url)
+            
         if item.extra == "novedades" and "/serie" in url:
             if not item_local.url or episodio_serie == 0:
                 item_local.url = url
@@ -1204,8 +1211,12 @@ def listado_busqueda(item):
         
         #Guardamos el resto de variables del vídeo
         item_local.url = url
+        if not item_local.url.startswith("http"):                           #Si le falta el http.: lo ponemos
+            item_local.url = scrapertools.find_single_match(item_local.channel_host, '(\w+:)//') + item_local.url
         item_local.thumbnail = scrapedthumbnail
-        item_local.contentThumbnail = scrapedthumbnail
+        if not item_local.thumbnail.startswith("http"):                     #Si le falta el http.: lo ponemos
+            item_local.thumbnail = scrapertools.find_single_match(item_local.channel_host, '(\w+:)//') + item_local.thumbnail
+        item_local.contentThumbnail = item_local.thumbnail
 
         #Guardamos el año que puede venir en la url, por si luego no hay resultados desde TMDB
         try:
@@ -2019,7 +2030,12 @@ def episodios(item):
             
             item_local = item.clone()                                           #Creamos copia local de Item por episodio
             item_local.url = url
-            item_local.contentThumbnail = thumb
+            if not item_local.url.startswith("http"):                           #Si le falta el http.: lo ponemos
+                item_local.url = scrapertools.find_single_match(item_local.channel_host, '(\w+:)//') + item_local.url
+            item_local.thumbnail = thumb
+            if not item_local.thumbnail.startswith("http"):                     #Si le falta el http.: lo ponemos
+                item_local.thumbnail = scrapertools.find_single_match(item_local.channel_host, '(\w+:)//') + item_local.thumbnail
+            item_local.contentThumbnail = item_local.thumbnail
             estado = True                                                       #Buena calidad de datos por defecto
 
             if "<span" in info:                                                 # new style

--- a/plugin.video.alfa/platformcode/launcher.py
+++ b/plugin.video.alfa/platformcode/launcher.py
@@ -392,12 +392,15 @@ def play_from_library(item):
     import xbmcgui
     import xbmcplugin
     import xbmc
+    from time import sleep
+    
     # Intentamos reproducir una imagen (esto no hace nada y ademas no da error)
     xbmcplugin.setResolvedUrl(int(sys.argv[1]), True,
                               xbmcgui.ListItem(
                                   path=os.path.join(config.get_runtime_path(), "resources", "subtitle.mp4")))
 
     # Por si acaso la imagen hiciera (en futuras versiones) le damos a stop para detener la reproduccion
+    sleep(0.5)              ### Si no se pone esto se bloquea Kodi
     xbmc.Player().stop()
 
     # modificamos el action (actualmente la videoteca necesita "findvideos" ya que es donde se buscan las fuentes
@@ -421,7 +424,6 @@ def play_from_library(item):
 
         while platformtools.is_playing():
                 # Ventana convencional
-                from time import sleep
                 sleep(5)
         p_dialog.update(50, '')
 


### PR DESCRIPTION
- Launcher: Kodi se bloqueaba en el pseudo "play" del vídeo "subtitle".  Hay que poner un "sleep(0.5)" antes del Stop

- MejorTorrent: cambio de dominio

- NewPct1: A veces falta el http.: al principio de thumbs y urls