### PR TITLE
[Mediaserver] Añadir la inicialización que falta

### DIFF
--- a/mediaserver/alfa.py
+++ b/mediaserver/alfa.py
@@ -83,6 +83,10 @@ def start():
         logger.info("--------------------------------------------------------------------")
         show_info()
 
+        # Identifica la dirección Proxy y la lista de alternativas
+        from core import proxytools
+        proxytools.get_proxy_list()
+
         flag = True
         while flag:
             time.sleep(1)


### PR DESCRIPTION
En el addon normal se carga videolibrary_service.py que realiza esta inicialización. En la mediaserver no, haciendo que la funcionalidad que inicializa no funcionara.