### PR TITLE
global search changes

### DIFF
--- a/plugin.video.alfa/channels/search.json
+++ b/plugin.video.alfa/channels/search.json
@@ -5,4 +5,47 @@
   "adult": false,
   "thumbnail": "",
   "banner": "",
-  "categories": []}
+  "categories": [],
+  "settings": [
+    {
+      "id": "last_search",
+      "type": "bool",
+      "label": "@60678",
+      "default": true,
+      "enabled": true,
+      "visible": true
+    },
+    {
+      "id": "saved_searches_limit",
+      "type": "list",
+      "label": "@60677",
+      "default": 0,
+      "enabled": true,
+      "visible": true,
+      "lvalues": [
+        "10",
+        "20",
+        "30",
+        "40"
+      ]
+    },
+    {
+      "id": "result_mode",
+      "type": "list",
+      "label": "@60657",
+      "default": 0,
+      "enabled": true,
+      "visible": true,
+      "lvalues": ["@60675","@60676"]
+    },
+    {
+      "id": "thread_number",
+      "type": "list",
+      "label": "@60673",
+      "default": 0,
+      "enabled": true,
+      "visible": true,
+      "lvalues": ["auto","1","2","4","6","8","16","24","32","64"]
+    }
+  ]
+}

--- a/plugin.video.alfa/channels/search.py
+++ b/plugin.video.alfa/channels/search.py
@@ -180,9 +180,6 @@ def channel_search(item):
 
     channel_list, channel_titles = get_channels(item)
 
-    import requests
-    session = requests.Session()
-
     searching += channel_list
     searching_titles += channel_titles
     cnt = 0
@@ -192,7 +189,7 @@ def channel_search(item):
     config.set_setting('tmdb_active', False)
 
     with futures.ThreadPoolExecutor(max_workers=set_workers()) as executor:
-        c_results = [executor.submit(get_channel_results, ch, item, session) for ch in channel_list]
+        c_results = [executor.submit(get_channel_results, ch, item) for ch in channel_list]
 
         for res in futures.as_completed(c_results):
             cnt += 1
@@ -259,9 +256,9 @@ def channel_search(item):
         # to_temp[key] = grouped
         if config.get_setting('result_mode', 'search') == 0:
             if not config.get_setting('unify'):
-                title = ch_name + str(len(grouped))
+                title = ch_name + ' [COLOR yellow](' + str(len(grouped)) + ')[/COLOR]'
             else:
-                title = '%s %s' % (len(grouped), config.get_localized_string(70695))
+                title = '[COLOR yellow]%s %s[/COLOR]' % (len(grouped), config.get_localized_string(70695))
             res_count += len(grouped)
             plot=''
 
@@ -285,7 +282,7 @@ def channel_search(item):
     return valid + results
 
 
-def get_channel_results(ch, item, session):
+def get_channel_results(ch, item):
     max_results = 10
     results = list()
 
@@ -298,7 +295,6 @@ def get_channel_results(ch, item, session):
 
     if search_action:
         for search_ in search_action:
-            search_.session = session
             try:
                 results.extend(module.search(search_, item.text))
             except:
@@ -562,20 +558,20 @@ def actor_list(item):
 
         rol = elem.get('known_for_department', '')
         rol = prof.get(rol, rol)
-        # genero = elem.get('gender', 0)
-        # if genero == 1 and rol in prof:
-        #     rol += 'a'
-        #     rol = rol.replace('Actora', 'Actriz')
+        genero = elem.get('gender', 0)
+        if genero == 1 and rol in prof:
+            rol += 'a'
+            rol = rol.replace('Actora', 'Actriz')
 
         know_for = elem.get('known_for', '')
         cast_id = elem.get('id', '')
         if know_for:
             t_k = know_for[0].get('title', '')
             if t_k:
-                plot = '%s in %s' % (rol, t_k)
+                plot = '%s en [COLOR limegreen]%s[/COLOR] y otras' % (rol, t_k)
 
         thumbnail = 'http://image.tmdb.org/t/p/original%s' % elem.get('profile_path', '')
-        title = name + rol
+        title = '%s [COLOR grey](%s)[/COLOR]' % (name, rol)
 
         discovery = {'url': 'person/%s/combined_credits' % cast_id, 'page': '1',
                      'sort_by': 'primary_release_date.desc', 'language': def_lang}
@@ -586,7 +582,7 @@ def actor_list(item):
     if len(results) > 19:
         next_ = item.page + 1
         itemlist.append(Item(channel=item.channel, title=config.get_localized_string(30992), action='actor_list',
-                             page=next_, thumbnail=thumbnail,
+                             page=next_, thumbnail=thumbnail, text_color='gold',
                              searched_text=item.searched_text))
     return itemlist
 
@@ -700,7 +696,7 @@ def get_from_temp(item):
     results = [Item().fromurl(elem) for elem in item.itemlist[prevp:nextp]]
 
     if nextp < nTotal:
-        results.append(Item(channel='search', title=config.get_localized_string(30992),
+        results.append(Item(channel='search', title='[COLOR yellow]' + config.get_localized_string(30992) + '[/COLOR]',
                             action='get_from_temp', itemlist=item.itemlist, page=item.page + 1))
 
     tmdb.set_infoLabels_itemlist(results, True)

--- a/plugin.video.alfa/channels/search.py
+++ b/plugin.video.alfa/channels/search.py
@@ -258,7 +258,7 @@ def channel_search(item):
             if not config.get_setting('unify'):
                 title = ch_name + ' [COLOR yellow](' + str(len(grouped)) + ')[/COLOR]'
             else:
-                title = '[COLOR yellow]%s %s[/COLOR]' % (len(grouped), config.get_localized_string(70695))
+                title = '[COLOR yellow](%s)[/COLOR]' % (len(grouped))
             res_count += len(grouped)
             plot=''
 
@@ -266,7 +266,7 @@ def channel_search(item):
                 plot += it.title +'\n'
             ch_thumb = channeltools.get_channel_parameters(key)['thumbnail']
             results.append(Item(channel='search', title=title,
-                                action='get_from_temp', thumbnail=ch_thumb, itemlist=[ris.tourl() for ris in grouped], plot=plot, page=1))
+                                action='get_from_temp', thumbnail=ch_thumb, itemlist=[ris.tourl() for ris in grouped], plot=plot, page=1, from_channel=key))
 
 
 

--- a/plugin.video.alfa/channels/search.py
+++ b/plugin.video.alfa/channels/search.py
@@ -3,44 +3,38 @@
 # -*- Created for Alfa-addon -*-
 # -*- By the Alfa Develop Group -*-
 
-import os
-import json
-import time
+import os, json, time, inspect, channelselector
 from lib.concurrent import futures
 from core.item import Item
-from core import tmdb
-from core import scrapertools
-from core import channeltools
-import channelselector
+from core import tmdb, scrapertools, channeltools, filetools, jsontools
 from channelselector import get_thumb
-from platformcode import logger
-from platformcode import config
-from platformcode import platformtools
-from platformcode import unify
+from platformcode import logger, config, platformtools, unify
 
+import gc
+gc.disable()
+
+import xbmcaddon
+addon = xbmcaddon.Addon('metadata.themoviedb.org')
+def_lang = addon.getSetting('language')
 
 def mainlist(item):
     logger.info()
 
-    itemlist = list()
+    itemlist = [Item(channel=item.channel, title=config.get_localized_string(70276), action='new_search', mode='all', thumbnail=get_thumb("search.png")),
 
-    itemlist.append(Item(channel=item.channel, title='Búsqueda General', action='new_search', mode='all',
-                         thumbnail=get_thumb("search_generic.png")))
+                Item(channel=item.channel, title=config.get_localized_string(70741) % config.get_localized_string(30122), action='new_search', mode='movie', thumbnail=get_thumb("search_movie.png")),
 
-    itemlist.append(Item(channel=item.channel, title='Buscar Película', action='new_search', mode='movie',
-                         thumbnail=get_thumb("search.png")))
+                Item(channel=item.channel, title=config.get_localized_string(70741) % config.get_localized_string(30123), action='new_search', mode='tvshow', thumbnail=get_thumb("search_tvshow.png")),
 
-    itemlist.append(Item(channel=item.channel, title='Buscar Serie', action='new_search', mode='tvshow',
-                         thumbnail=get_thumb("search_tvshow.png")))
+                Item(channel=item.channel, title=config.get_localized_string(70741) % config.get_localized_string(70314), action='new_search', page=1, mode='person', thumbnail=get_thumb("search_star.png")),
 
-    itemlist.append(Item(channel=item.channel, title='Buscar Actor/Actriz', action='new_search',
-                         page=1, mode='person', thumbnail=get_thumb("search_star.png")))
+                Item(channel=item.channel, title=config.get_localized_string(59995), action='saved_search', thumbnail=get_thumb('search.png')),
 
-    itemlist.append(Item(channel=item.channel, title='Más opciones de búsqueda', action='sub_menu',
-                         thumbnail=get_thumb('search_more.png')))
+                Item(channel=item.channel, title=config.get_localized_string(60420), action='sub_menu', thumbnail=get_thumb('search.png')),
 
-    itemlist.append(Item(channel=item.channel, title='Seleccionar canales para la búsqueda', action='opciones',
-                         thumbnail=get_thumb('setting_0.png')))
+                Item(channel=item.channel, title=config.get_localized_string(59994), action='opciones', thumbnail=get_thumb('setting_0.png')),
+
+                Item(channel=item.channel, title=config.get_localized_string(30100), action='settings', thumbnail=get_thumb('setting_0.png'))]
 
     itemlist = set_context(itemlist)
 
@@ -50,49 +44,56 @@ def mainlist(item):
 def sub_menu(item):
     logger.info()
 
-    itemlist = list()
+    itemlist = [Item(channel=item.channel, action='genres_menu', title=config.get_localized_string(70306), mode='movie', thumbnail=get_thumb("channels_movie_genre.png")),
 
-    itemlist.append(Item(channel="tvmoviedb", action="mainlist", title=config.get_localized_string(70274),
-                         thumbnail=get_thumb("search.png")))
+                Item(channel=item.channel, action='years_menu', title=config.get_localized_string(70742), mode='movie', thumbnail=get_thumb("channels_movie_year.png")),
 
-    itemlist.append(Item(channel=item.channel, action='genres_menu', title=config.get_localized_string(70306),
-                         mode='movie',  thumbnail=get_thumb("genres.png")))
+                Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70307), search_type='list', list_type='movie/popular', mode='movie', thumbnail=get_thumb("channels_movie_popular.png")),
 
-    itemlist.append(Item(channel=item.channel, action='years_menu', title='Películas por Año',
-                         mode='movie', thumbnail=get_thumb("years.png")))
+                Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70308), search_type='list', list_type='movie/top_rated', mode='movie', thumbnail=get_thumb("channels_movie_top.png")),
 
-    itemlist.append(Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70307),
-                         search_type='list', list_type='movie/popular', mode='movie',
-                         thumbnail=get_thumb("popular.png")))
+                Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70309), search_type='list', list_type='movie/now_playing', mode='movie', thumbnail=get_thumb("channels_movie_now_playing.png")),
 
-    itemlist.append(Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70308),
-                         search_type='list', list_type='movie/top_rated', mode='movie',
-                         thumbnail=get_thumb("top_rated.png")))
+                Item(channel=item.channel, action='genres_menu', title=config.get_localized_string(70310), mode='tvshow', thumbnail=get_thumb("channels_tvshow_genre.png")),
 
-    itemlist.append(Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70309),
-                         search_type='list', list_type='movie/now_playing', mode='movie',
-                         thumbnail=get_thumb("now_playing.png")))
+                Item(channel=item.channel, action='years_menu', title=config.get_localized_string(70743), mode='tvshow', thumbnail=get_thumb("channels_tvshow_year.png")),
 
-    itemlist.append(Item(channel=item.channel, action='genres_menu', title=config.get_localized_string(70310),
-                         mode='tvshow', thumbnail=get_thumb("genres.png")))
+                Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70311), search_type='list', list_type='tv/popular', mode='tvshow', thumbnail=get_thumb("popular.png")),
 
-    itemlist.append(Item(channel=item.channel, action='years_menu', title='Series por Año',
-                         mode='tvshow', thumbnail=get_thumb("years.png")))
+                Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70312), search_type='list', list_type='tv/on_the_air', mode='tvshow', thumbnail=get_thumb("channels_tvshow_on_the_air.png")),
 
-    itemlist.append(Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70311),
-                         search_type='list', list_type='tv/popular', mode='tvshow',
-                         thumbnail=get_thumb("popular.png")))
+                Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70313), search_type='list', list_type='tv/top_rated', mode='tvshow', thumbnail=get_thumb("channels_tvshow_top.png")),
 
-    itemlist.append(Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70312),
-                         search_type='list', list_type='tv/on_the_air', mode='tvshow',
-                         thumbnail=get_thumb("on_the_air.png")))
-
-    itemlist.append(Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70313),
-                         search_type='list', list_type='tv/top_rated', mode='tvshow',
-                         thumbnail=get_thumb("top_rated.png")))
+                Item(channel="tvmoviedb", action="mainlist", title=config.get_localized_string(70274), thumbnail=get_thumb("search.png"))]
 
     itemlist = set_context(itemlist)
 
+    return itemlist
+
+def saved_search(item):
+    logger.info()
+
+    itemlist = list()
+    saved_searches_list = get_saved_searches()
+
+
+    for saved_search_text in saved_searches_list:
+        itemlist.append(
+            Item(channel=item.channel,
+                 action="new_search",
+                 title=saved_search_text.split('{}')[0],
+                 search_text=saved_search_text.split('{}')[0],
+                 mode='all',
+                 thumbnail=get_thumb('search.png')))
+
+    if len(saved_searches_list) > 0:
+        itemlist.append(
+            Item(channel=item.channel,
+                 action="clear_saved_searches",
+                 title=config.get_localized_string(60417),
+                 thumbnail=get_thumb('search.png')))
+
+    itemlist = set_context(itemlist)
     return itemlist
 
 
@@ -100,10 +101,17 @@ def new_search(item):
     logger.info()
 
     itemlist = []
+    if channeltools.get_channel_setting('last_search', 'search'):
+        last_search = channeltools.get_channel_setting('Last_searched', 'search', '')
+    else:
+        last_search = ''
 
-    last_search = channeltools.get_channel_setting('Last_searched', 'search', '')
-    searched_text = platformtools.dialog_input(default=last_search, heading='Alfa (Busqueda)')
+    if item.search_text:
+        searched_text = item.search_text
+    else:
+        searched_text = platformtools.dialog_input(default=last_search, heading='')
 
+    save_search(searched_text)
     if not searched_text:
         return
 
@@ -113,7 +121,7 @@ def new_search(item):
     if item.mode == 'person':
         item.searched_text = searched_text
         return actor_list(item)
-    
+
     if item.mode != 'all':
         tmdb_info = tmdb.Tmdb(texto_buscado=searched_text, tipo=item.mode.replace('show', ''))
         results = tmdb_info.results
@@ -124,10 +132,10 @@ def new_search(item):
             else:
                 title = result['name']
                 item.mode = 'tvshow'
-            
+
             thumbnail = result.get('thumbnail', '')
             fanart = result.get('fanart', '')
-            
+
             new_item = Item(channel=item.channel,
                             action='channel_search',
                             title=title,
@@ -155,30 +163,36 @@ def new_search(item):
 
 
 def channel_search(item):
-    logger.info()
+    logger.info(item)
 
     start = time.time()
     searching = list()
+    searching_titles = list()
     results = list()
     valid = list()
     ch_list = dict()
-    to_temp = dict()
     mode = item.mode
     max_results = 10
+    if item.infoLabels['title']:
+        item.text = item.infoLabels['title']
 
     searched_id = item.infoLabels['tmdb_id']
 
-    channel_list = get_channels(item)
+    channel_list, channel_titles = get_channels(item)
+
+    import requests
+    session = requests.Session()
 
     searching += channel_list
+    searching_titles += channel_titles
     cnt = 0
 
-    progress = platformtools.dialog_progress('Buscando %s ...' % item.title, "Restan %s canales" % len(channel_list),
-                                             str(searching))
+    progress = platformtools.dialog_progress(config.get_localized_string(30993) % item.title, config.get_localized_string(70744) % len(channel_list),
+                                             str(searching_titles))
     config.set_setting('tmdb_active', False)
 
-    with futures.ThreadPoolExecutor() as executor:
-        c_results = [executor.submit(get_channel_results, ch, item) for ch in channel_list]
+    with futures.ThreadPoolExecutor(max_workers=set_workers()) as executor:
+        c_results = [executor.submit(get_channel_results, ch, item, session) for ch in channel_list]
 
         for res in futures.as_completed(c_results):
             cnt += 1
@@ -189,32 +203,34 @@ def channel_search(item):
             if progress.iscanceled():
                 break
             if finished in searching:
+                searching_titles.remove(searching_titles[searching.index(finished)])
                 searching.remove(finished)
-                progress.update((cnt * 100) / len(channel_list), "Restan %s canales" % str(len(channel_list)-cnt),
-                                str(searching))
+                progress.update((cnt * 100) / len(channel_list), config.get_localized_string(70744) % str(len(channel_list) - cnt),
+                                str(searching_titles))
 
     progress.close()
 
     cnt = 0
-    progress = platformtools.dialog_progress('Buscando %s ...' % item.title, "Preparando Resultados",
-                                             'Por favor espere...')
+    progress = platformtools.dialog_progress(config.get_localized_string(30993) % item.title, config.get_localized_string(60295),
+                                             config.get_localized_string(60293))
 
     config.set_setting('tmdb_active', True)
-
+    res_count = 0
     for key, value in ch_list.items():
+        ch_name = channel_titles[channel_list.index(key)]
         grouped = list()
         cnt += 1
-        progress.update((cnt * 100) / len(ch_list), "Preparando Resultados", 'Por favor espere...')
+        progress.update((cnt * 100) / len(ch_list), config.get_localized_string(60295), config.get_localized_string(60293))
         if len(value) <= max_results and item.mode != 'all':
             if len(value) == 1:
-                if not value[0].action or 'siguiente' in value[0].title.lower():
+                if not value[0].action or config.get_localized_string(70006).lower() in value[0].title.lower():
                     continue
             tmdb.set_infoLabels_itemlist(value, True, forced=True)
             for elem in value:
                 if not elem.infoLabels.get('year', ""):
                     elem.infoLabels['year'] = '-'
                     tmdb.set_infoLabels_item(elem, True)
-                
+
                 if elem.infoLabels['tmdb_id'] == searched_id:
                     elem.from_channel = key
                     if not config.get_setting('unify'):
@@ -227,7 +243,12 @@ def channel_search(item):
             if it in valid:
                 continue
             if mode == 'all' or (it.contentType and mode == it.contentType):
-                grouped.append(it)
+                if config.get_setting('result_mode', 'search') != 0:
+                    if config.get_localized_string(30992) not in it.title:
+                        it.title += ch_name
+                        results.append(it)
+                else:
+                    grouped.append(it)
             elif (mode == 'movie' and it.contentTitle) or (mode == 'tvshow' and (it.contentSerieName or it.show)):
                 grouped.append(it)
             else:
@@ -235,41 +256,49 @@ def channel_search(item):
 
         if not grouped:
             continue
-        to_temp[key] = grouped
+        # to_temp[key] = grouped
+        if config.get_setting('result_mode', 'search') == 0:
+            if not config.get_setting('unify'):
+                title = ch_name + str(len(grouped))
+            else:
+                title = '%s %s' % (len(grouped), config.get_localized_string(70695))
+            res_count += len(grouped)
+            plot=''
 
-        if not config.get_setting('unify'):
-            title = '[COLOR yellow](%s) RESULTADOS EN[/COLOR] [%s]' % (len(grouped), key)
-        else:
-            title = '[COLOR yellow](%s) RESULTADOS EN[/COLOR]' % (len(grouped))
+            for it in grouped:
+                plot += it.title +'\n'
+            ch_thumb = channeltools.get_channel_parameters(key)['thumbnail']
+            results.append(Item(channel='search', title=title,
+                                action='get_from_temp', thumbnail=ch_thumb, itemlist=[ris.tourl() for ris in grouped], plot=plot, page=1))
 
-        ch_thumb = channeltools.get_channel_parameters(key)['thumbnail']
-        results.append(Item(channel='search', title=title,
-                            action='get_from_temp', thumbnail=ch_thumb, from_channel=key, page=1))
 
-    results = sorted(results, key=lambda it: it.from_channel)
 
-    send_to_temp(to_temp)
+    # send_to_temp(to_temp)
     config.set_setting('tmdb_active', True)
-
-    logger.debug('Finalizada en %s segs (%s canales)' % (str(time.time() - start), str(len(channel_list))))
-
+    if item.mode == 'all':
+        if config.get_setting('result_mode', 'search') != 0:
+            res_count = len(results)
+        results = sorted(results, key=lambda it: it.title)
+        results_statistic = config.get_localized_string(59972) % (item.title, res_count, time.time() - start)
+        results.insert(0, Item(title = results_statistic))
+    # logger.debug(results_statistic)
     return valid + results
 
 
-def get_channel_results(ch, item):
-
+def get_channel_results(ch, item, session):
     max_results = 10
     results = list()
 
     ch_params = channeltools.get_channel_parameters(ch)
 
-    exec "from channels import " + ch_params["channel"] + " as module"
+    exec("from channels import " + ch_params["channel"] + " as module")
 
     mainlist = module.mainlist(Item(channel=ch_params["channel"]))
     search_action = [elem for elem in mainlist if elem.action == "search"]
 
     if search_action:
         for search_ in search_action:
+            search_.session = session
             try:
                 results.extend(module.search(search_, item.text))
             except:
@@ -283,7 +312,7 @@ def get_channel_results(ch, item):
     if len(results) < 0 and len(results) < max_results and item.mode != 'all':
 
         if len(results) == 1:
-            if not results[0].action or 'siguiente' in results[0].title.lower():
+            if not results[0].action or config.get_localized_string(30992).lower() in results[0].title.lower():
                 return [ch, []]
 
         results = get_info(results)
@@ -302,6 +331,7 @@ def get_channels(item):
     logger.info()
 
     channels_list = list()
+    title_list = list()
     all_channels = channelselector.filterchannels('all')
 
     for ch in all_channels:
@@ -321,19 +351,26 @@ def get_channels(item):
         if item.mode == 'all' or (item.mode in list_cat):
             if config.get_setting("include_in_global_search", channel):
                 channels_list.append(channel)
+                title_list.append(ch_param.get('title', channel))
 
-    return channels_list
+    return channels_list, title_list
 
 
 def opciones(item):
     return setting_channel_new(item)
 
+def settings(item):
+    return platformtools.show_channel_settings(caption=config.get_localized_string(59993))
+
+def set_workers():
+    list_mode=[None,1,2,4,6,8,16,24,32,64]
+    index = config.get_setting('thread_number', 'search')
+    return list_mode[index]
 
 def setting_channel_new(item):
     import xbmcgui
 
-    # Cargar lista de opciones (canales activos del usuario y que permitan búsqueda global)
-    # ------------------------
+    # Load list of options (active user channels that allow global search)
     lista = []
     ids = []
     lista_lang = []
@@ -345,7 +382,7 @@ def setting_channel_new(item):
 
         channel_parameters = channeltools.get_channel_parameters(channel.channel)
 
-        # No incluir si en la configuracion del canal no existe "include_in_global_search"
+        # Do not include if "include_in_global_search" does not exist in the channel configuration
         if not channel_parameters['include_in_global_search']:
             continue
 
@@ -359,17 +396,16 @@ def setting_channel_new(item):
         lista_lang.append(channel_parameters['language'])
         lista_ctgs.append(channel_parameters['categories'])
 
-    # Diálogo para pre-seleccionar
-    # ----------------------------
+    # Pre-select dialog
     preselecciones = [
-        'Buscar con la selección actual',
-        'Modificar selección actual',
+        config.get_localized_string(70570),
+        config.get_localized_string(70571),
         'Modificar partiendo de Recomendados',
         'Modificar partiendo de Frecuentes',
-        'Modificar partiendo de Todos',
-        'Modificar partiendo de Ninguno',
-        'Modificar partiendo de Castellano',
-        'Modificar partiendo de Latino'
+        config.get_localized_string(70572),
+        config.get_localized_string(70573),
+        config.get_localized_string(70574),
+        config.get_localized_string(70575)
     ]
     presel_values = ['skip', 'actual', 'recom', 'freq', 'all', 'none', 'cast', 'lat']
 
@@ -377,19 +413,19 @@ def setting_channel_new(item):
     if config.get_setting('adult_mode') > 0:
         categs.append('adult')
     for c in categs:
-        preselecciones.append('Modificar partiendo de %s' % config.get_localized_category(c))
+        preselecciones.append(config.get_localized_string(70577) + config.get_localized_category(c))
         presel_values.append(c)
 
     if item.action == 'setting_channel':  # Configuración de los canales incluídos en la búsqueda
         del preselecciones[0]
         del presel_values[0]
-    # else: # Llamada desde "buscar en otros canales" (se puede saltar la selección e ir directo a la búsqueda)
+    # else: # Call from "search on other channels" (you can skip the selection and go directly to the search)
 
     ret = platformtools.dialog_select(config.get_localized_string(59994), preselecciones)
     if ret == -1:
-        return False  # pedido cancel
+        return False  # order cancel
     if presel_values[ret] == 'skip':
-        return True  # continuar sin modificar
+        return True  # continue unmodified
     elif presel_values[ret] == 'none':
         preselect = []
     elif presel_values[ret] == 'all':
@@ -405,7 +441,7 @@ def setting_channel_new(item):
             channel_status = config.get_setting('include_in_global_search', canal)
             if channel_status:
                 preselect.append(i)
-    
+
     elif presel_values[ret] == 'recom':
         preselect = []
         for i, canal in enumerate(ids):
@@ -425,15 +461,13 @@ def setting_channel_new(item):
             if presel_values[ret] in ctgs:
                 preselect.append(i)
 
-    # Diálogo para seleccionar
-    # ------------------------
+    # Dialog to select
     ret = xbmcgui.Dialog().multiselect(config.get_localized_string(59994), lista, preselect=preselect, useDetails=True)
     if not ret:
-        return False  # pedido cancel
+        return False  # order cancel
     seleccionados = [ids[i] for i in ret]
 
-    # Guardar cambios en canales para la búsqueda
-    # -------------------------------------------
+    # Save changes to search channels
     for canal in ids:
         channel_status = config.get_setting('include_in_global_search', canal)
         # if not channel_status:
@@ -448,73 +482,73 @@ def setting_channel_new(item):
 
 
 def genres_menu(item):
-
     itemlist = []
     mode = item.mode.replace('show', '')
 
     genres = tmdb.get_genres(mode)
     for key, value in genres[mode].items():
         discovery = {'url': 'discover/%s' % mode, 'with_genres': key,
-                     'language': 'es', 'page': '1'}
-        
+                     'language': def_lang, 'page': '1'}
+
         itemlist.append(Item(channel=item.channel, title=value, page=1,
                              action='discover_list', discovery=discovery,
                              mode=item.mode))
-
+    channelselector.thumb(itemlist)
     return sorted(itemlist, key=lambda it: it.title)
+
 
 def years_menu(item):
     import datetime
-    itemlist= []
+    itemlist = []
 
     mode = item.mode.replace('show', '')
 
     par_year = 'primary_release_year'
+    thumb = channelselector.get_thumb('channels_movie_year.png')
 
     if mode != 'movie':
         par_year = 'first_air_date_year'
+        thumb = channelselector.get_thumb('channels_tvshow_year.png')
 
     c_year = datetime.datetime.now().year + 1
     l_year = c_year - 31
-    
-    for year in range(l_year, c_year):
-        discovery =  {'url': 'discover/%s' % mode, 'page': '1',
-                     '%s' % par_year: '%s' % year,
-                     'sort_by': 'popularity.desc', 'language': 'es'}
 
+    for year in range(l_year, c_year):
+        discovery = {'url': 'discover/%s' % mode, 'page': '1',
+                     '%s' % par_year: '%s' % year,
+                     'sort_by': 'popularity.desc', 'language': def_lang}
 
         itemlist.append(Item(channel=item.channel, title=str(year), action='discover_list',
-                             discovery=discovery,  mode=item.mode, year_=str(year)))
+                             discovery=discovery, mode=item.mode, year_=str(year), thumbnail=thumb))
     itemlist.reverse()
-    itemlist.append(Item(channel=item.channel, title='Introduzca otro año...', url='',
-                          action="year_cus", mode=item.mode, par_year=par_year))
+    itemlist.append(Item(channel=item.channel, title=config.get_localized_string(70745), url='',
+                         action="year_cus", mode=item.mode, par_year=par_year))
 
     return itemlist
 
+
 def year_cus(item):
-    
     mode = item.mode.replace('show', '')
-    
-    heading = 'Introduzca Año (4 digitos)'
+
+    heading = config.get_localized_string(70042)
     year = platformtools.dialog_numeric(0, heading, default="")
-    item.discovery =  {'url': 'discover/%s' % mode, 'page': '1',
-                     '%s' % item.par_year: '%s' % year,
-                     'sort_by': 'popularity.desc', 'language': 'es'}
+    item.discovery = {'url': 'discover/%s' % mode, 'page': '1',
+                      '%s' % item.par_year: '%s' % year,
+                      'sort_by': 'popularity.desc', 'language': def_lang}
     item.action = "discover_list"
     if year and len(year) == 4:
         return discover_list(item)
 
-        
 
 def actor_list(item):
     itemlist = []
-    
-    dict_ = {'url': 'search/person', 'language': 'es', 'query': item.searched_text, 'page': item.page}
-    
+
+    dict_ = {'url': 'search/person', 'language': def_lang, 'query': item.searched_text, 'page': item.page}
+
     prof = {'Acting': 'Actor', 'Directing': 'Director', 'Production': 'Productor'}
     plot = ''
     item.search_type = 'person'
-    
+
     tmdb_inf = tmdb.discovery(item, dict_=dict_)
     results = tmdb_inf.results
 
@@ -525,34 +559,34 @@ def actor_list(item):
         name = elem.get('name', '')
         if not name:
             continue
-        
+
         rol = elem.get('known_for_department', '')
         rol = prof.get(rol, rol)
-        genero = elem.get('gender', 0)
-        if genero == 1 and rol in prof:
-            rol += 'a'
-            rol = rol.replace('Actora', 'Actriz')
+        # genero = elem.get('gender', 0)
+        # if genero == 1 and rol in prof:
+        #     rol += 'a'
+        #     rol = rol.replace('Actora', 'Actriz')
 
         know_for = elem.get('known_for', '')
         cast_id = elem.get('id', '')
         if know_for:
             t_k = know_for[0].get('title', '')
             if t_k:
-                plot = '%s en [COLOR limegreen]%s[/COLOR] y otras' % (rol, t_k)
-        
+                plot = '%s in %s' % (rol, t_k)
+
         thumbnail = 'http://image.tmdb.org/t/p/original%s' % elem.get('profile_path', '')
-        title = '%s [COLOR grey](%s)[/COLOR]' % (name, rol)
+        title = name + rol
 
         discovery = {'url': 'person/%s/combined_credits' % cast_id, 'page': '1',
-                     'sort_by': 'primary_release_date.desc', 'language': 'es'}
-        
+                     'sort_by': 'primary_release_date.desc', 'language': def_lang}
+
         itemlist.append(Item(channel=item.channel, title=title, action='discover_list', cast_='cast',
                              discovery=discovery, thumbnail=thumbnail, plot=plot, page=1))
 
     if len(results) > 19:
         next_ = item.page + 1
-        itemlist.append(Item(channel=item.channel, title="Pagina Siguiente >>", action='actor_list',
-                             page=next_, thumbnail=thumbnail, text_color='gold',
+        itemlist.append(Item(channel=item.channel, title=config.get_localized_string(30992), action='actor_list',
+                             page=next_, thumbnail=thumbnail,
                              searched_text=item.searched_text))
     return itemlist
 
@@ -560,7 +594,7 @@ def actor_list(item):
 def discover_list(item):
     import datetime
     itemlist = []
-    
+
     year = 0
     tmdb_inf = tmdb.discovery(item, dict_=item.discovery, cast=item.cast_)
     result = tmdb_inf.results
@@ -574,13 +608,12 @@ def discover_list(item):
             title = unify.normalize(elem['name']).capitalize()
             tvshow = True
         elem['tmdb_id'] = elem['id']
-        
+
         mode = item.mode or elem['media_type']
         thumbnail = elem.get('thumbnail', '')
         fanart = elem.get('fanart', '')
 
         if item.cast_:
-
             release = elem.get('release_date', '0000') or elem.get('first_air_date', '0000')
             year = scrapertools.find_single_match(release, r'(\d{4})')
 
@@ -609,7 +642,7 @@ def discover_list(item):
         itemlist.append(Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70065),
                              list_type=item.list_type, discovery=item.discovery, text_color='gold'))
     elif len(result) > 19:
-        next_page = str(int(item.page)+1)
+        next_page = str(int(item.page) + 1)
 
         itemlist.append(Item(channel=item.channel, action='discover_list', title=config.get_localized_string(70065),
                              list_type=item.list_type, search_type=item.search_type, mode=item.mode, page=next_page,
@@ -643,51 +676,32 @@ def set_context(itemlist):
     logger.info()
 
     for elem in itemlist:
-        elem.context = [{"title": "Elegir canales",
+        elem.context = [{"title": config.get_localized_string(60412),
                          "action": "setting_channel_new",
+                         "channel": "search"},
+                        {"title": config.get_localized_string(60415),
+                         "action": "settings",
+                         "channel": "search"},
+                        {"title": config.get_localized_string(60416),
+                         "action": "clear_saved_searches",
                          "channel": "search"}]
 
     return itemlist
 
 
-def send_to_temp(to_temp):
-    logger.info()
-
-    temp_path = os.path.join(config.get_data_path(), 'temp_search.json')
-    temp = dict()
-
-    for key, value in to_temp.items():
-        new_list = list()
-        for elem in value:
-            new_list.append(elem.tourl())
-        temp[key] = new_list
-
-    with open(temp_path, "w") as temp_file:
-        json.dump(temp, temp_file)
-
-
 def get_from_temp(item):
     logger.info()
-    
+
     n = 30
-    nextp = n*item.page
-    prevp = n*(item.page - 1)
-    
-    temp_path = os.path.join(config.get_data_path(), 'temp_search.json')
-    results = list()
+    nTotal = len(item.itemlist)
+    nextp = n * item.page
+    prevp = n * (item.page - 1)
 
-    with open(temp_path, "r") as temp_list:
-        from_temp = json.load(temp_list)
+    results = [Item().fromurl(elem) for elem in item.itemlist[prevp:nextp]]
 
-    for elem in from_temp[item.from_channel]:
-        results.append(Item().fromurl(elem))
-
-    old_results = results
-    results = results[prevp:nextp]
-
-    if len(results) == n and len(old_results*item.page) != n:
-        results.append(Item(channel='search', title='[COLOR yellow]Pagina Siguiente >>[/COLOR]',
-                            action='get_from_temp', from_channel=item.from_channel, page=item.page+1))
+    if nextp < nTotal:
+        results.append(Item(channel='search', title=config.get_localized_string(30992),
+                            action='get_from_temp', itemlist=item.itemlist, page=item.page + 1))
 
     tmdb.set_infoLabels_itemlist(results, True)
     for elem in results:
@@ -696,3 +710,36 @@ def get_from_temp(item):
             tmdb.set_infoLabels_item(elem, True)
 
     return results
+
+
+def save_search(text):
+    if text:
+        saved_searches_limit = int((10, 20, 30, 40)[int(config.get_setting("saved_searches_limit", "search"))])
+
+        current_saved_searches_list = config.get_setting("saved_searches_list", "search")
+        if current_saved_searches_list is None:
+            saved_searches_list = []
+        else:
+            saved_searches_list = list(current_saved_searches_list)
+
+        if text in saved_searches_list:
+            saved_searches_list.remove(text)
+
+        saved_searches_list.insert(0, text)
+
+        config.set_setting("saved_searches_list", saved_searches_list[:saved_searches_limit], "search")
+
+
+def clear_saved_searches(item):
+    config.set_setting("saved_searches_list", list(), "search")
+    platformtools.dialog_ok(config.get_localized_string(60423), config.get_localized_string(60424))
+
+
+def get_saved_searches():
+    current_saved_searches_list = config.get_setting("saved_searches_list", "search")
+    if current_saved_searches_list is None:
+        saved_searches_list = []
+    else:
+        saved_searches_list = list(current_saved_searches_list)
+
+    return saved_searches_list

--- a/plugin.video.alfa/resources/language/Catalan/strings.po
+++ b/plugin.video.alfa/resources/language/Catalan/strings.po
@@ -1789,8 +1789,8 @@ msgid "Delete saved searches"
 msgstr "Suprimeix les cerques desades"
 
 msgctxt "#60420"
-msgid "More Options"
-msgstr "Mes Opccions"
+msgid "More search options"
+msgstr "Més opcions de cerca"
 
 msgctxt "#60421"
 msgid "Channels included in the global search "

--- a/plugin.video.alfa/resources/language/English/strings.po
+++ b/plugin.video.alfa/resources/language/English/strings.po
@@ -3802,7 +3802,7 @@ msgid "Add Torrent channels in search"
 msgstr ""
 
 msgctxt "#70276"
-msgid "Search by Title"
+msgid "Search by title"
 msgstr ""
 
 msgctxt "#70277"

--- a/plugin.video.alfa/resources/language/English/strings.po
+++ b/plugin.video.alfa/resources/language/English/strings.po
@@ -2670,7 +2670,7 @@ msgid "Global Search"
 msgstr ""
 
 msgctxt "#60673"
-msgid "MultiThread Search"
+msgid "Number of Search Threads"
 msgstr ""
 
 msgctxt "#60674"
@@ -3802,7 +3802,7 @@ msgid "Add Torrent channels in search"
 msgstr ""
 
 msgctxt "#70276"
-msgid "Search by title"
+msgid "Search by Title"
 msgstr ""
 
 msgctxt "#70277"
@@ -4934,3 +4934,55 @@ msgstr ""
 msgctxt "#70562"
 msgid "Autoplay (Enable autoplay on all supported channels)"
 msgstr "Autoplay (Enable autoplay on all supported channels)"
+
+msgctxt "#70570"
+msgid "Search with current selection"
+msgstr ""
+
+msgctxt "#70571"
+msgid "Modify current selection"
+msgstr ""
+
+msgctxt "#70572"
+msgid "Modify from All"
+msgstr ""
+
+msgctxt "#70573"
+msgid "Modify starting from None"
+msgstr ""
+
+msgctxt "#70574"
+msgid "Modify starting from Castellano"
+msgstr ""
+
+msgctxt "#70575"
+msgid "Modify starting from Latino"
+msgstr ""
+
+msgctxt "#70576"
+msgid "Modify starting from Italian"
+msgstr ""
+
+msgctxt "#70577"
+msgid "Modify starting from "
+msgstr ""
+
+msgctxt "#70741"
+msgid "Search %s"
+msgstr ""
+
+msgctxt "#70742"
+msgid "Movies by Year"
+msgstr ""
+
+msgctxt "#70743"
+msgid "Series by Year"
+msgstr ""
+
+msgctxt "#70744"
+msgid "%s channels remaining"
+msgstr ""
+
+msgctxt "#70745"
+msgid "Enter another year..."
+msgstr ""

--- a/plugin.video.alfa/resources/language/English/strings.po
+++ b/plugin.video.alfa/resources/language/English/strings.po
@@ -1694,7 +1694,7 @@ msgid "Delete saved searches"
 msgstr ""
 
 msgctxt "#60420"
-msgid "More Options"
+msgid "More search options"
 msgstr ""
 
 msgctxt "#60421"

--- a/plugin.video.alfa/resources/language/Italian/strings.po
+++ b/plugin.video.alfa/resources/language/Italian/strings.po
@@ -1682,7 +1682,7 @@ msgid "Delete saved searches"
 msgstr "Cancella ricerche salvate"
 
 msgctxt "#60420"
-msgid "More Options"
+msgid "More search options"
 msgstr "Altre opzioni"
 
 msgctxt "#60421"

--- a/plugin.video.alfa/resources/language/Italian/strings.po
+++ b/plugin.video.alfa/resources/language/Italian/strings.po
@@ -283,11 +283,11 @@ msgstr "Informazioni Persona"
 
 msgctxt "#30980"
 msgid "Search by Title"
-msgstr "Cerca per Titolo ..."
+msgstr "Cerca per Titolo"
 
 msgctxt "#30981"
 msgid "Search by Person"
-msgstr "Cerca per Persona ..."
+msgstr "Cerca per Persona"
 
 msgctxt "#30982"
 msgid "Search by Company"
@@ -307,7 +307,7 @@ msgstr "Migliori"
 
 msgctxt "#30986"
 msgid "Search by Collection"
-msgstr "Ricerca per Collezione ..."
+msgstr "Ricerca per Collezione"
 
 msgctxt "#30987"
 msgid "Genre"
@@ -315,15 +315,15 @@ msgstr "Genere"
 
 msgctxt "#30988"
 msgid "Search by Year"
-msgstr "Ricerca per Anno ..."
+msgstr "Ricerca per Anno"
 
 msgctxt "#30989"
 msgid "Search Similar Movies"
-msgstr "Cerca Film Simili ..."
+msgstr "Cerca Film Simili"
 
 msgctxt "#30990"
 msgid "Search TV show"
-msgstr "Cerca Serie TV ..."
+msgstr "Cerca Serie TV"
 
 msgctxt "#30991"
 msgid "Library"
@@ -335,11 +335,11 @@ msgstr "Successivo"
 
 msgctxt "#30993"
 msgid "Looking for %s..."
-msgstr "Ricerca di %s ..."
+msgstr "Ricerca di %s..."
 
 msgctxt "#30994"
 msgid "Searching in %s..."
-msgstr "Sto cercando in %s ..."
+msgstr "Sto cercando in %s..."
 
 msgctxt "#30995"
 msgid "%d found so far: %s"
@@ -2658,8 +2658,8 @@ msgid "Global Search"
 msgstr "Ricerca globale"
 
 msgctxt "#60673"
-msgid "MultiThread Search"
-msgstr "Ricerca MultiThread"
+msgid "Number of Search Threads"
+msgstr "Numero di Threads di Ricerca"
 
 msgctxt "#60674"
 msgid "Show Results:"
@@ -3782,8 +3782,8 @@ msgid "Add Torrent channels in search"
 msgstr "Includere i canali Torrent nella ricerca"
 
 msgctxt "#70276"
-msgid "Search by title"
-msgstr "Cerca per titolo"
+msgid "Search by Title"
+msgstr "Cerca per Titolo"
 
 msgctxt "#70277"
 msgid "MediaServer Language (Restart Required)"
@@ -4919,7 +4919,58 @@ msgctxt "#70561"
 msgid "Search Similar
 msgstr "Cerca Simili"
 
-
 msgctxt "#70562"
 msgid "Autoplay (Enable autoplay in all channels)"
 msgstr "Autoplay (Abilita autoplay in tutti i canali)"
+
+msgctxt "#70570"
+msgid "Search with current selection"
+msgstr "Cerca con la selezione corrente"
+
+msgctxt "#70571"
+msgid "Modify current selection"
+msgstr "Modifica la selezione corrente"
+
+msgctxt "#70572"
+msgid "Modify from All"
+msgstr "Modifica partendo da Tutto"
+
+msgctxt "#70573"
+msgid "Modify starting from None"
+msgstr "Modifica partendo da Nessuno"
+
+msgctxt "#70574"
+msgid "Modify starting from Castellano"
+msgstr "Modifica partendo da Castellano"
+
+msgctxt "#70575"
+msgid "Modify starting from Latino"
+msgstr "Modifica partendo da Latino"
+
+msgctxt "#70576"
+msgid "Modify starting from Italian"
+msgstr "Modifica partendo da Italiano"
+
+msgctxt "#70577"
+msgid "Modify starting from "
+msgstr "Modifica partendo da "
+
+msgctxt "#70741"
+msgid "Search %s"
+msgstr "Cerca %s"
+
+msgctxt "#70742"
+msgid "Movies by Year"
+msgstr "Film per Anno"
+
+msgctxt "#70743"
+msgid "Series by Year"
+msgstr "Serie per Anno"
+
+msgctxt "#70744"
+msgid "%s channels remaining"
+msgstr "%s canali restanti"
+
+msgctxt "#70745"
+msgid "Enter another year..."
+msgstr "Inserisci un altro anno..."

--- a/plugin.video.alfa/resources/language/Spanish (Argentina)/strings.po
+++ b/plugin.video.alfa/resources/language/Spanish (Argentina)/strings.po
@@ -1694,8 +1694,8 @@ msgid "Delete saved searches"
 msgstr "Borrar búsquedas guardadas"
 
 msgctxt "#60420"
-msgid "More Options"
-msgstr "Otros Ajustes"
+msgid "More search options"
+msgstr "Más opciones de búsqueda"
 
 msgctxt "#60421"
 msgid "Channels included in the global search "

--- a/plugin.video.alfa/resources/language/Spanish (Argentina)/strings.po
+++ b/plugin.video.alfa/resources/language/Spanish (Argentina)/strings.po
@@ -4934,3 +4934,51 @@ msgstr "Buscar Similares"
 msgctxt "#70562"
 msgid "Autoplay (Enable autoplay on all supported channels)"
 msgstr "Autoplay (Habilitar autoplay en todos los canales soportados)"
+
+msgctxt "#70570"
+msgid "Search with current selection"
+msgstr "Buscar con la selección actual"
+
+msgctxt "#70571"
+msgid "Modify current selection"
+msgstr "Modificar selección actual"
+
+msgctxt "#70572"
+msgid "Modify from All"
+msgstr "Modificar partiendo de Todos"
+
+msgctxt "#70573"
+msgid "Modify starting from None"
+msgstr "Modificar partiendo de Ninguno"
+
+msgctxt "#70574"
+msgid "Modify starting from Castellano"
+msgstr "Modificar partiendo de Castellano"
+
+msgctxt "#70575"
+msgid "Modify starting from Latino"
+msgstr "Modificar partiendo de Latino"
+
+msgctxt "#70577"
+msgid "Modify starting from "
+msgstr "Modificar partiendo de "
+
+msgctxt "#70741"
+msgid "Search %s"
+msgstr "Buscar %s"
+
+msgctxt "#70742"
+msgid "Movies by Year"
+msgstr "Películas por Año"
+
+msgctxt "#70743"
+msgid "Series by Year"
+msgstr "Series por Año"
+
+msgctxt "#70744"
+msgid "%s channels remaining"
+msgstr "Restan %s canales"
+
+msgctxt "#70745"
+msgid "Enter another year..."
+msgstr "Introduzca otro año..."

--- a/plugin.video.alfa/resources/language/Spanish (Mexico)/strings.po
+++ b/plugin.video.alfa/resources/language/Spanish (Mexico)/strings.po
@@ -1694,8 +1694,8 @@ msgid "Delete saved searches"
 msgstr "Borrar búsquedas guardadas"
 
 msgctxt "#60420"
-msgid "More Options"
-msgstr "Otros Ajustes"
+msgid "More search options"
+msgstr "Más opciones de búsqueda"
 
 msgctxt "#60421"
 msgid "Channels included in the global search "

--- a/plugin.video.alfa/resources/language/Spanish (Mexico)/strings.po
+++ b/plugin.video.alfa/resources/language/Spanish (Mexico)/strings.po
@@ -4934,3 +4934,51 @@ msgstr "Buscar Similares"
 msgctxt "#70562"
 msgid "Autoplay (Enable autoplay on all supported channels)"
 msgstr "Autoplay (Habilitar autoplay en todos los canales soportados)"
+
+msgctxt "#70570"
+msgid "Search with current selection"
+msgstr "Buscar con la selección actual"
+
+msgctxt "#70571"
+msgid "Modify current selection"
+msgstr "Modificar selección actual"
+
+msgctxt "#70572"
+msgid "Modify from All"
+msgstr "Modificar partiendo de Todos"
+
+msgctxt "#70573"
+msgid "Modify starting from None"
+msgstr "Modificar partiendo de Ninguno"
+
+msgctxt "#70574"
+msgid "Modify starting from Castellano"
+msgstr "Modificar partiendo de Castellano"
+
+msgctxt "#70575"
+msgid "Modify starting from Latino"
+msgstr "Modificar partiendo de Latino"
+
+msgctxt "#70577"
+msgid "Modify starting from "
+msgstr "Modificar partiendo de "
+
+msgctxt "#70741"
+msgid "Search %s"
+msgstr "Buscar %s"
+
+msgctxt "#70742"
+msgid "Movies by Year"
+msgstr "Películas por Año"
+
+msgctxt "#70743"
+msgid "Series by Year"
+msgstr "Series por Año"
+
+msgctxt "#70744"
+msgid "%s channels remaining"
+msgstr "Restan %s canales"
+
+msgctxt "#70745"
+msgid "Enter another year..."
+msgstr "Introduzca otro año..."

--- a/plugin.video.alfa/resources/language/Spanish/strings.po
+++ b/plugin.video.alfa/resources/language/Spanish/strings.po
@@ -1694,8 +1694,8 @@ msgid "Delete saved searches"
 msgstr "Borrar búsquedas guardadas"
 
 msgctxt "#60420"
-msgid "More Options"
-msgstr "Otros Ajustes"
+msgid "More search options"
+msgstr "Más opciones de búsqueda"
 
 msgctxt "#60421"
 msgid "Channels included in the global search "

--- a/plugin.video.alfa/resources/language/Spanish/strings.po
+++ b/plugin.video.alfa/resources/language/Spanish/strings.po
@@ -4934,3 +4934,51 @@ msgstr "Buscar Similares"
 msgctxt "#70562"
 msgid "Autoplay (Enable autoplay on all supported channels)"
 msgstr "Autoplay (Habilitar autoplay en todos los canales soportados)"
+
+msgctxt "#70570"
+msgid "Search with current selection"
+msgstr "Buscar con la selección actual"
+
+msgctxt "#70571"
+msgid "Modify current selection"
+msgstr "Modificar selección actual"
+
+msgctxt "#70572"
+msgid "Modify from All"
+msgstr "Modificar partiendo de Todos"
+
+msgctxt "#70573"
+msgid "Modify starting from None"
+msgstr "Modificar partiendo de Ninguno"
+
+msgctxt "#70574"
+msgid "Modify starting from Castellano"
+msgstr "Modificar partiendo de Castellano"
+
+msgctxt "#70575"
+msgid "Modify starting from Latino"
+msgstr "Modificar partiendo de Latino"
+
+msgctxt "#70577"
+msgid "Modify starting from "
+msgstr "Modificar partiendo de "
+
+msgctxt "#70741"
+msgid "Search %s"
+msgstr "Buscar %s"
+
+msgctxt "#70742"
+msgid "Movies by Year"
+msgstr "Películas por Año"
+
+msgctxt "#70743"
+msgid "Series by Year"
+msgstr "Series por Año"
+
+msgctxt "#70744"
+msgid "%s channels remaining"
+msgstr "Restan %s canales"
+
+msgctxt "#70745"
+msgid "Enter another year..."
+msgstr "Introduzca otro año..."


### PR DESCRIPTION
List of changes:
-reimplemented settings from old search (saved search, remember last search ecc..)
-configurable maximum number of thread (on some platform may speedup, android for example seems to do it better with 4-6 threads only)
-show titles preview
-gc.disable to speedup a bit
-mostly localized

some other hints to speedup (not implemented):
- add a variable to all search item in all channels to recognise search type (movie, tvshow ecc..), if you are searching a film (using "search film" menu), you probably wont find in tvshows search, so you can skip

> search_action = [elem for elem in mainlist if elem.action == "search" and (item.mode == 'all' or elem.contentType == item.mode)]

- use the same requests session for all channels (initialized during search and passed by parameter), this avoid to re-do handshake (won't speedup so much, but a bit).
also this need to be implemented in channels

by KoD team