### PR TITLE
optimized render_items

### DIFF
--- a/plugin.video.alfa/core/scrapertools.py
+++ b/plugin.video.alfa/core/scrapertools.py
@@ -90,7 +90,7 @@ def unescape(text):
                 pass
         return text  # leave as is
 
-    return re.sub("&#?\w+;", str(fixup), str(text))
+    return re.sub("&#?\w+;", fixup, str(text))
 
     # Convierte los codigos html "&ntilde;" y lo reemplaza por "ñ" caracter unicode utf-8
 

--- a/plugin.video.alfa/platformcode/launcher.py
+++ b/plugin.video.alfa/platformcode/launcher.py
@@ -46,7 +46,13 @@ def run(item=None):
     if not item:
         # Extract item from sys.argv
         if sys.argv[2]:
-            item = Item().fromurl(sys.argv[2])
+            sp = sys.argv[2].split('&')
+            url = sp[0]
+            item = Item().fromurl(url)
+            if len(sp) > 1:
+                for e in sp[1:]:
+                    key, val = e.split('=')
+                    item.__setattr__(key, val)
 
         # If no item, this is mainlist
         else:

--- a/plugin.video.alfa/platformcode/platformtools.py
+++ b/plugin.video.alfa/platformcode/platformtools.py
@@ -193,8 +193,17 @@ def render_items(itemlist, parent_item):
         pass
     # logger.debug('unify_enabled: %s' % unify_enabled)
 
+    # for adding extendedinfo to contextual menu, if it's used
+    has_extendedinfo = xbmc.getCondVisibility('System.HasAddon(script.extendedinfo)')
+    # for adding superfavourites to contextual menu, if it's used
+    sf_file_path = xbmc.translatePath("special://home/addons/plugin.program.super.favourites/LaunchSFMenu.py")
+    check_sf = os.path.exists(sf_file_path)
+    superfavourites = check_sf and xbmc.getCondVisibility('System.HasAddon("plugin.program.super.favourites")')
+    num_version_xbmc = config.get_platform(True)['num_version']
+
     # Recorremos el itemlist
     for item in itemlist:
+        item_url = item.tourl()
         # logger.debug(item)
         # Si el item no contiene categoria, le ponemos la del item padre
         if item.category == "":
@@ -243,9 +252,11 @@ def render_items(itemlist, parent_item):
         # Añade headers a las imagenes si estan en un servidor con cloudflare
         if item.action == 'play':
             item.thumbnail = unify.thumbnail_type(item)
-        else:
+        # if cloudflare, cookies are needed to display images taken from site
+        # before checking domain (time consuming), checking if tmdb failed (so, images scraped from website are used)
+        if item.action in ['findvideos'] and not item.infoLabels['tmdb_id'] and item.channel in httptools.CF_LIST:
             item.thumbnail = httptools.get_url_headers(item.thumbnail)
-        item.fanart = httptools.get_url_headers(item.fanart)
+            item.fanart = httptools.get_url_headers(item.fanart)
 
         # IconImage para folder y video
         if item.folder:
@@ -289,7 +300,8 @@ def render_items(itemlist, parent_item):
 
         # Montamos el menu contextual
         if parent_item.channel != 'special':
-            context_commands = set_context_commands(item, parent_item)
+            context_commands = set_context_commands(item, item_url, parent_item, has_extendedinfo=has_extendedinfo,
+                                                    superfavourites=superfavourites, num_version_xbmc=num_version_xbmc)
         else:
             context_commands = []
         # Añadimos el menu contextual
@@ -300,7 +312,7 @@ def render_items(itemlist, parent_item):
 
         if not item.totalItems:
             item.totalItems = 0
-        xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url='%s?%s' % (sys.argv[0], item.tourl()),
+        xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url='%s?%s' % (sys.argv[0], item_url),
                                     listitem=listitem, isFolder=item.folder,
                                     totalItems=item.totalItems)
 
@@ -420,36 +432,43 @@ def set_infolabels(listitem, item, player=False):
                        'tvdb_id': 'None', 'tvshowtitle': 'tvshowtitle', 'type': 'None', 'userrating': 'userrating',
                        'url_scraper': 'None', 'votes': 'votes', 'writer': 'writer', 'year': 'year'}
 
-    infoLabels_kodi = {}
-
     if item.infoLabels:
-        if 'mediatype' not in item.infoLabels:
-            item.infoLabels['mediatype'] = item.contentType
-
         try:
-            for label_tag, label_value in list(item.infoLabels.items()):
-                try:
-                    # logger.debug(str(label_tag) + ': ' + str(infoLabels_dict[label_tag]))
-                    if infoLabels_dict[label_tag] != 'None':
-                        infoLabels_kodi.update({infoLabels_dict[label_tag]: item.infoLabels[label_tag]})
-                except:
-                    continue
-
+            infoLabels_kodi = {infoLabels_dict[label_tag]: item.infoLabels[label_tag] for label_tag, label_value in list(item.infoLabels.items()) if infoLabels_dict[label_tag] != 'None'}
             listitem.setInfo("video", infoLabels_kodi)
-
         except:
             listitem.setInfo("video", item.infoLabels)
             logger.error(item.infoLabels)
-            logger.error(infoLabels_kodi)
+    # infoLabels_kodi = {}
+    #
+    # if item.infoLabels:
+    #     if 'mediatype' not in item.infoLabels:
+    #         item.infoLabels['mediatype'] = item.contentType
+    #
+    #     try:
+    #         for label_tag, label_value in list(item.infoLabels.items()):
+    #             try:
+    #                 # logger.debug(str(label_tag) + ': ' + str(infoLabels_dict[label_tag]))
+    #                 if infoLabels_dict[label_tag] != 'None':
+    #                     infoLabels_kodi.update({infoLabels_dict[label_tag]: item.infoLabels[label_tag]})
+    #             except:
+    #                 continue
+    #
+    #         listitem.setInfo("video", infoLabels_kodi)
+    #
+    #     except:
+    #         listitem.setInfo("video", item.infoLabels)
+    #         logger.error(item.infoLabels)
+    #         logger.error(infoLabels_kodi)
+    #
+    # if player and not item.contentTitle:
+    #     listitem.setInfo("video", {"Title": item.title})
+    #
+    # elif not player:
+    #     listitem.setInfo("video", {"Title": item.title})
 
-    if player and not item.contentTitle:
-        listitem.setInfo("video", {"Title": item.title})
 
-    elif not player:
-        listitem.setInfo("video", {"Title": item.title})
-
-
-def set_context_commands(item, parent_item):
+def set_context_commands(item, item_url, parent_item, **kwargs):
     """
     Función para generar los menus contextuales.
         1. Partiendo de los datos de item.context
@@ -480,7 +499,6 @@ def set_context_commands(item, parent_item):
     @type parent_item: item
     """
     context_commands = []
-    num_version_xbmc = config.get_platform(True)['num_version']
 
     # Creamos un list con las diferentes opciones incluidas en item.context
     if isinstance(item.context, str):
@@ -489,43 +507,6 @@ def set_context_commands(item, parent_item):
         context = item.context
     else:
         context = []
-
-    if config.get_setting("faster_item_serialization"):
-        # logger.info("Reducing serialization!")
-        itemBK = item
-        item = Item()
-        item.action = itemBK.action
-        item.channel = itemBK.channel
-        infoLabels = {}
-        if itemBK.infoLabels["year"]:       infoLabels["year"] = itemBK.infoLabels["year"]
-        if itemBK.infoLabels["imdb_id"]:    infoLabels["imdb_id"] = itemBK.infoLabels["imdb_id"]
-        if itemBK.infoLabels["tmdb_id"]:    infoLabels["tmdb_id"] = itemBK.infoLabels["tmdb_id"]
-        if itemBK.infoLabels["tvdb_id"]:    infoLabels["tvdb_id"] = itemBK.infoLabels["tvdb_id"]
-        if itemBK.infoLabels["noscrap_id"]: infoLabels["noscrap_id"] = itemBK.infoLabels["noscrap_id"]
-        if len(infoLabels) > 0:             item.infoLabels = infoLabels
-
-        if itemBK.thumbnail:                item.thumbnail = itemBK.thumbnail
-        if itemBK.extra:                    item.extra = itemBK.extra
-        if itemBK.contentEpisodeNumber:     item.contentEpisodeNumber = itemBK.contentEpisodeNumber
-        if itemBK.contentEpisodeTitle:      item.contentEpisodeTitle = itemBK.contentEpisodeTitle
-        if itemBK.contentPlot:              item.contentPlot = itemBK.contentPlot
-        if itemBK.contentQuality:           item.contentQuality = itemBK.contentQuality
-        if itemBK.contentSeason:            item.contentSeason = itemBK.contentSeason
-        if itemBK.contentSerieName:         item.contentSerieName = itemBK.contentSerieName
-        if itemBK.contentThumbnail:         item.contentThumbnail = itemBK.contentThumbnail
-        if itemBK.contentTitle:             item.contentTitle = itemBK.contentTitle
-        if itemBK.contentType:              item.contentType = itemBK.contentType
-        if itemBK.duration:                 item.duration = itemBK.duration
-        if itemBK.plot:                     item.plot = itemBK.plot
-        if itemBK.quality:                  item.quality = itemBK.quality
-        if itemBK.show:                     item.show = itemBK.show
-        if itemBK.title:                    item.title = itemBK.title
-        if itemBK.viewcontent:              item.viewcontent = itemBK.viewcontent
-
-    # itemJson = item.tojson()
-    # logger.info("Elemento: {0} bytes".format(len(itemJson)))
-    # logger.info(itemJson)
-    # logger.info("--------------------------------------------------------------")
 
     # Opciones segun item.context
     for command in context:
@@ -554,19 +535,17 @@ def set_context_commands(item, parent_item):
             else:
                 context_commands.append(
                     (command["title"], "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], item.clone(**command).tourl())))
-
     # No añadir más opciones predefinidas si se está dentro de Alfavoritos
     if parent_item.channel == 'alfavorites':
         return context_commands
-
-    # Opciones segun criterios, solo si el item no es un tag (etiqueta), ni es "Añadir a la videoteca", etc...
+        # Opciones segun criterios, solo si el item no es un tag (etiqueta), ni es "Añadir a la videoteca", etc...
     if item.action and item.action not in ["add_pelicula_to_library", "add_serie_to_library", "buscartrailer", "actualizar_titulos"]:
         # Mostrar informacion: si el item tiene plot suponemos q es una serie, temporada, capitulo o pelicula
-        if item.infoLabels['plot'] and (num_version_xbmc < 17.0 or item.contentType == 'season'):
+        if item.infoLabels['plot'] and (kwargs.get('num_version_xbmc') < 17.0 or item.contentType == 'season'):
             context_commands.append((config.get_localized_string(60348), "XBMC.Action(Info)"))
 
         # ExtendedInfo: Si está instalado el addon y se cumplen una serie de condiciones
-        if xbmc.getCondVisibility('System.HasAddon(script.extendedinfo)') \
+        if kwargs.get('has_extendedinfo') \
                 and config.get_setting("extended_info") == True:
             if item.contentType == "episode" and item.contentEpisodeNumber and item.contentSeason \
                     and (item.infoLabels['tmdb_id'] or item.contentSerieName):
@@ -598,14 +577,13 @@ def set_context_commands(item, parent_item):
 
                 context_commands.append(("ExtendedInfo",
                                          "XBMC.RunScript(script.extendedinfo,info=extendedinfo,%s)" % param))
-
         # InfoPlus
         if config.get_setting("infoplus"):
             #if item.infoLabels['tmdb_id'] or item.infoLabels['imdb_id'] or item.infoLabels['tvdb_id'] or \
             #        (item.contentTitle and item.infoLabels["year"]) or item.contentSerieName:
             if item.infoLabels['tmdb_id'] or item.infoLabels['imdb_id'] or item.infoLabels['tvdb_id']:
-                context_commands.append(("InfoPlus", "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], item.clone(
-                    channel="infoplus", action="start", from_channel=item.channel).tourl())))
+                context_commands.append(("InfoPlus", "XBMC.RunPlugin(%s?%s&%s)" % (sys.argv[0], item_url,
+                            'channel=infoplus&action=start&from_channel=' + item.channel)))
 
         # Ir al Menu Principal (channel.mainlist)
         """
@@ -616,22 +594,20 @@ def set_context_commands(item, parent_item):
         """
 
         # Añadir a Favoritos
-        if num_version_xbmc < 17.0 and \
-                ((item.channel not in ["favorites", "videolibrary", "help", ""]
-                  or item.action in ["update_videolibrary"]) and parent_item.channel != "favorites"):
-            context_commands.append((config.get_localized_string(30155), "XBMC.RunPlugin(%s?%s)" %
-                                     (sys.argv[0], item.clone(channel="favorites", action="addFavourite",
-                                                              from_channel=item.channel,
-                                                              from_action=item.action).tourl())))
-        
+        if kwargs.get('num_version_xbmc') < 17.0 and (item.channel not in ["favorites", "videolibrary", "help", ""]
+                  or item.action in ["update_videolibrary"]) and parent_item.channel != "favorites":
+            context_commands.append(
+            (config.get_localized_string(30155), "XBMC.RunPlugin(%s?%s&%s)" %
+             (sys.argv[0], item_url,
+              'channel=favorites&action=addFavourite&from_channel=' + item.channel + '&from_action=' + item.action)))
+
         # Añadir a Alfavoritos (Mis enlaces)
         if item.channel not in ["favorites", "videolibrary", "help", ""] and parent_item.channel != "favorites":
             context_commands.append(
-                ('[COLOR blue]%s[/COLOR]' % config.get_localized_string(70557), "XBMC.RunPlugin(%s?%s)" %
-                 (sys.argv[0], item.clone(channel="alfavorites", action="addFavourite",
-                                          from_channel=item.channel,
-                                          from_action=item.action).tourl())))
-
+                ('[COLOR blue]%s[/COLOR]' % config.get_localized_string(70557), "XBMC.RunPlugin(%s?%s&%s)" %
+                 (sys.argv[0], item_url, urllib.urlencode({'channel': "alfavorites", 'action': "addFavourite",
+                                          'from_channel': item.channel,
+                                          'from_action': item.action}))))
         # Buscar en otros canales
         if item.contentType in ['movie', 'tvshow'] and item.channel != 'search' and item.action not in ['play']:
 
@@ -647,20 +623,17 @@ def set_context_commands(item, parent_item):
                 mediatype = item.contentType
 
             context_commands.append((config.get_localized_string(60350),
-                                     "XBMC.Container.Update (%s?%s)" % (sys.argv[0],
-                                                                        item.clone(channel='search',
-                                                                                   action="from_context",
-                                                                                   from_channel=item.channel,
-                                                                                   contextual=True,
-                                                                                   text=item.wanted).tourl())))
+                                     "XBMC.Container.Update (%s?%s&%s)" % (sys.argv[0],
+                                                    item_url, urllib.urlencode({'channel': 'search',
+                                                                                'action': "from_context",
+                                                                                   'from_channel': item.channel,
+                                                                                   'contextual': True,
+                                                                                   'text': item.wanted}))))
 
             context_commands.append(
-                ("[COLOR yellow]%s[/COLOR]" % config.get_localized_string(70561), "XBMC.Container.Update (%s?%s)" % (
-                    sys.argv[0], item.clone(channel='search', action='from_context', search_type='list', page='1',
-                                            list_type='%s/%s/similar' % (
-                                            mediatype, item.infoLabels['tmdb_id'])).tourl())))
-
-        # Definir como Pagina de inicio
+                ("[COLOR yellow]%s[/COLOR]" % config.get_localized_string(70561), "XBMC.Container.Update (%s?%s&%s)" % (
+                    sys.argv[0], item_url, 'channel=search&action=from_context&search_type=list&page=1&list_type=%s/%s/similar' % (mediatype, item.infoLabels['tmdb_id']))))
+                # Definir como Pagina de inicio
         if config.get_setting('start_page'):
             if item.action not in ['episodios', 'seasons', 'findvideos', 'play']:
                 context_commands.insert(0, (config.get_localized_string(60351),
@@ -672,14 +645,12 @@ def set_context_commands(item, parent_item):
         if item.channel != "videolibrary":
             # Añadir Serie a la videoteca
             if item.action in ["episodios", "get_episodios"] and item.contentSerieName:
-                context_commands.append((config.get_localized_string(60352), "XBMC.RunPlugin(%s?%s)" %
-                                         (sys.argv[0], item.clone(action="add_serie_to_library",
-                                                                  from_action=item.action).tourl())))
+                context_commands.append((config.get_localized_string(60352), "XBMC.RunPlugin(%s?%s&%s)" %
+                                         (sys.argv[0], item_url, 'action=add_serie_to_library&from_action=' + item.action)))
             # Añadir Pelicula a videoteca
             elif item.action in ["detail", "findvideos"] and item.contentType == 'movie' and item.contentTitle:
-                context_commands.append((config.get_localized_string(60353), "XBMC.RunPlugin(%s?%s)" %
-                                         (sys.argv[0], item.clone(action="add_pelicula_to_library",
-                                                                  from_action=item.action).tourl())))
+                context_commands.append((config.get_localized_string(60353), "XBMC.RunPlugin(%s?%s&%s)" %
+                                         (sys.argv[0], item_url, 'action=add_pelicula_to_library&from_action=' + item.action)))
 
         if item.channel != "downloads":
             if item.channel == 'videolibrary' and item.contentChannel:
@@ -688,63 +659,55 @@ def set_context_commands(item, parent_item):
                 channel_p = item.channel
             # Descargar pelicula
             if item.contentType == "movie" and item.contentTitle:
-                context_commands.append((config.get_localized_string(60354), "XBMC.RunPlugin(%s?%s)" %
-                                         (sys.argv[0], item.clone(channel="downloads", action="save_download",
-                                                                  from_channel=channel_p, from_action=item.action)
-                                                                  .tourl())))
+                context_commands.append((config.get_localized_string(60354), "XBMC.RunPlugin(%s?%s&%s)" %
+                                         (sys.argv[0], item_url, 'channel=downloads&action=save_download&from_channel=' + item.channel + '&from_action=' + item.action)))
 
             elif item.contentSerieName:
                 # Descargar serie
                 if item.contentType == "tvshow" or (item.contentType == "episode" and item.server == 'torrent'):
-                    context_commands.append((config.get_localized_string(60355), "XBMC.RunPlugin(%s?%s)" %
-                                             (sys.argv[0], item.clone(channel="downloads", action="save_download",
-                                                                      from_channel=channel_p, sub_action="tvshow", 
-                                                                      from_action=item.action).tourl())))
+                    context_commands.append((config.get_localized_string(60355), "XBMC.RunPlugin(%s?%s&%s)" %
+                                             (sys.argv[0], item_url, 'channel=downloads&action=save_download&from_channel=' + channel_p + '&sub_action=tvshow' +
+                                                  '&from_action=' + item.action)))
                 # Descargar serie NO vistos
                 if item.contentType == "episode" and item.server == 'torrent' and item.channel == 'videolibrary':
-                    context_commands.append((config.get_localized_string(60355)+' NO Vistos', "XBMC.RunPlugin(%s?%s)" %
-                                             (sys.argv[0], item.clone(channel="downloads", action="save_download",
-                                                                      from_channel=channel_p, sub_action="unseen", 
-                                                                      from_action=item.action).tourl())))
+                    context_commands.append(
+                        (config.get_localized_string(60355) + ' NO Vistos', "XBMC.RunPlugin(%s?%s&%s)" %
+                         (sys.argv[0], item_url, 'channel=downloads&action=save_download&from_channel=' + channel_p + '&sub_action=unseen' +
+                                                  '&from_action=' + item.action)))
                 # Descargar episodio
                 if item.contentType == "episode":
-                    context_commands.append((config.get_localized_string(60356), "XBMC.RunPlugin(%s?%s)" %
-                                             (sys.argv[0], item.clone(channel="downloads", action="save_download",
-                                                                      from_channel=channel_p,
-                                                                      from_action=item.action).tourl())))
+                    context_commands.append((config.get_localized_string(60356), "XBMC.RunPlugin(%s?%s&%s)" %
+                                             (sys.argv[0], item_url, 'channel=downloads&action=save_download&from_channel=' + channel_p +
+                                                  '&from_action=' + item.action)))
                 # Descargar temporada
                 if item.contentType == "season" or (item.contentType == "episode" and item.server == 'torrent'):
-                    context_commands.append((config.get_localized_string(60357), "XBMC.RunPlugin(%s?%s)" %
-                                             (sys.argv[0], item.clone(channel="downloads", action="save_download",
-                                                                      from_channel=channel_p, sub_action="season",
-                                                                      from_action=item.action).tourl())))
+                    context_commands.append((config.get_localized_string(60357), "XBMC.RunPlugin(%s?%s&%s)" %
+                                             (sys.argv[0], item_url, 'channel=downloads&action=save_download&from_channel=' + channel_p + '&sub_action=season' +
+                                                  '&from_action=' + item.action)))
 
         # Abrir configuración
         if parent_item.channel not in ["setting", "news", "search"] and item.action == "play":
+            # pre-serialized: Item(channel="setting", action="mainlist").tourl()
             context_commands.append((config.get_localized_string(60358), "XBMC.Container.Update(%s?%s)" %
-                                     (sys.argv[0], Item(channel="setting", action="mainlist").tourl())))
+                                     (sys.argv[0], 'ewogICAgImFjdGlvbiI6ICJtYWlubGlzdCIsCiAgICAiY2hhbm5lbCI6ICJzZXR0aW5ncyIKfQo=')))
 
         # Buscar Trailer
         if item.action == "findvideos" or "buscar_trailer" in context:
             context_commands.append(
-                (config.get_localized_string(60359), "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], item.clone(
-                    channel="trailertools", action="buscartrailer", contextual=True).tourl())))
+                (config.get_localized_string(60359), "XBMC.RunPlugin(%s?%s)" % (sys.argv[0], urllib.urlencode({
+                    'channel': "trailertools", 'action': "buscartrailer", 'contextual': True}))))
 
-    # Añadir SuperFavourites al menu contextual (1.0.53 o superior necesario)
-    sf_file_path = xbmc.translatePath("special://home/addons/plugin.program.super.favourites/LaunchSFMenu.py")
-    check_sf = os.path.exists(sf_file_path)
-    if check_sf and xbmc.getCondVisibility('System.HasAddon("plugin.program.super.favourites")'):
-        context_commands.append((config.get_localized_string(60361),
+        if kwargs.get('superfavourites'):
+            context_commands.append((config.get_localized_string(60361),
                                  "XBMC.RunScript(special://home/addons/plugin.program.super.favourites/LaunchSFMenu.py)"))
 
     context_commands = sorted(context_commands, key=lambda comand: comand[0])
-    
+
     # Menu Rapido
+    # pre-serialized
+    # Item(channel='side_menu', action="open_menu").tourl()
     context_commands.insert(0, (config.get_localized_string(60360),
-                                "XBMC.Container.Update (%s?%s)" % (sys.argv[0], Item(channel='side_menu',
-                                                                                     action="open_menu",
-                                                                                     parent=parent_item.tourl()).tourl(
-                                ))))
+                                "XBMC.Container.Update (%s?%s)" % (sys.argv[0], 'ewogICAgImFjdGlvbiI6ICJvcGVuX21lbnUiLAogICAgImNoYW5uZWwiOiAic2lkZV9tZW51Igp9Cg==')))
     return context_commands
 
 

--- a/plugin.video.alfa/platformcode/platformtools.py
+++ b/plugin.video.alfa/platformcode/platformtools.py
@@ -254,7 +254,7 @@ def render_items(itemlist, parent_item):
             item.thumbnail = unify.thumbnail_type(item)
         # if cloudflare, cookies are needed to display images taken from site
         # before checking domain (time consuming), checking if tmdb failed (so, images scraped from website are used)
-        if item.action in ['findvideos'] and not item.infoLabels['tmdb_id'] and item.channel in httptools.CF_LIST:
+        if item.action in ['findvideos'] and not item.infoLabels['tmdb_id'] and scrapertoolsV2.get_domain_from_url(item.url) in httptools.CF_LIST:
             item.thumbnail = httptools.get_url_headers(item.thumbnail)
             item.fanart = httptools.get_url_headers(item.fanart)
 
@@ -433,6 +433,8 @@ def set_infolabels(listitem, item, player=False):
                        'url_scraper': 'None', 'votes': 'votes', 'writer': 'writer', 'year': 'year'}
 
     if item.infoLabels:
+        if 'mediatype' not in item.infoLabels:
+            item.infoLabels['mediatype'] = item.contentType
         try:
             infoLabels_kodi = {infoLabels_dict[label_tag]: item.infoLabels[label_tag] for label_tag, label_value in list(item.infoLabels.items()) if infoLabels_dict[label_tag] != 'None'}
             listitem.setInfo("video", infoLabels_kodi)
@@ -461,11 +463,11 @@ def set_infolabels(listitem, item, player=False):
     #         logger.error(item.infoLabels)
     #         logger.error(infoLabels_kodi)
     #
-    # if player and not item.contentTitle:
-    #     listitem.setInfo("video", {"Title": item.title})
-    #
-    # elif not player:
-    #     listitem.setInfo("video", {"Title": item.title})
+    if player and not item.contentTitle:
+        listitem.setInfo("video", {"Title": item.title})
+
+    elif not player:
+        listitem.setInfo("video", {"Title": item.title})
 
 
 def set_context_commands(item, item_url, parent_item, **kwargs):

--- a/plugin.video.alfa/resources/settings.xml
+++ b/plugin.video.alfa/resources/settings.xml
@@ -11,7 +11,7 @@
         <setting id="channel_language" type="labelenum" values="all|cast|lat" label="30019" default="all"/>
         <setting id="trakt_sync" type="bool" label="70109" default="false"/>
         <setting id="forceview" type="bool" label="30043" default="false"/>
-        <setting id="faster_item_serialization" type="bool" label="30300" default="false"/>
+<!--        <setting id="faster_item_serialization" type="bool" label="30300" default="false"/>-->
         <setting id="debug" type="bool" label="30003" default="false"/>
         <setting label="70169" type="lsep"/>
         <setting id="resolve_priority" type="enum" label="70110" lvalues="70164|70165|70166" default="0"/>


### PR DESCRIPTION
Hi,
as i promised, here's an optimized version of context-menus, since i had time, i've also included most optmizations done in KoD at render_items, but starting from your version to maintain compatibility (a thing i'm not sure at 100%, told me if you found something that behave differently).
There is still something that i don't understand so i've not touched, but it should still be a good improvement.
Also ask if some changes are not clear.

You can measure speed by the time difference between these 2 strings in log:
alfa.platformcode.platformtools [render_items] INICIO render_items
alfa.platformcode.platformtools [render_items] FINAL render_items

On modern PCs you won't see much improvements (on mine, 50ms over 200-300 ms), but on slower devices will save much (on my android phone i've measured 800 ms less, in allcalidad -> novedades), on bad tvboxes probably more.

Note: i've fixed also this thing, as i've noticed:
![image](https://user-images.githubusercontent.com/10120390/80280341-c4862a00-8703-11ea-8951-a8e4dde7b816.png)
edit: github seems to not like the changed line separator, use your editor to review the code.