### PR TITLE
Increased API search results limit from 10 to 100

### DIFF
--- a/plugin.video.alfa/channels/animeflv.py
+++ b/plugin.video.alfa/channels/animeflv.py
@@ -80,7 +80,7 @@ def search(item, texto):
     item.url = urlparse.urljoin(HOST, "api/animes/search")
     
     texto = texto.replace(" ", "+")
-    post = "value=%s" % texto
+    post = "value=%s&limit=100" % texto
     
     try:
         dict_data = httptools.downloadpage(item.url, post=post).json


### PR DESCRIPTION
A limit of just ten results is usually insufficient in most searches.