### PR TITLE
Patching compatibility error between python versions

### DIFF
--- a/plugin.video.alfa/core/trakt_tools.py
+++ b/plugin.video.alfa/core/trakt_tools.py
@@ -296,6 +296,7 @@ def wait_for_update_trakt():
     t = Thread(update_all)
     t.setDaemon(True)
     t.start()
+    if "is_alive" in dir(t): t.isAlive = t.is_alive
     t.isAlive()
 
 def update_all():


### PR DESCRIPTION
in Ubuntu 21.04 the python version has a modified thread class where isAlive is deprecated