### PR TITLE
Arreglos en búsquedas en BTDigg, Videolibrary y Torrent

### DIFF
--- a/plugin.video.alfa/channels/divxtotal.py
+++ b/plugin.video.alfa/channels/divxtotal.py
@@ -92,7 +92,7 @@ finds = {'find': dict([('find', [{'tag': ['table'], 'class': ['table']}]),
          'url_replace': [], 
          'controls': {'duplicates': [], 'min_temp': min_temp, 'url_base64': True, 'add_video_to_videolibrary': True, 'cnt_tot': 15, 
                       'get_lang': False, 'reverse': False, 'videolab_status': True, 'tmdb_extended_info': True, 'seasons_search': False, 
-                      'host_torrent': host, 'btdigg': True},
+                      'host_torrent': host, 'btdigg': True, 'btdigg_search': True},
          'timeout': timeout}
 AlfaChannel = DictionaryAllChannel(host, movie_path=movie_path, tv_path=tv_path, canonical=canonical, finds=finds, 
                                    idiomas=IDIOMAS, language=language, list_language=list_language, list_servers=list_servers, 

--- a/plugin.video.alfa/channels/dontorrent.py
+++ b/plugin.video.alfa/channels/dontorrent.py
@@ -121,7 +121,7 @@ finds = {'find': {'find_all': [{'tag': ['div'], 'class': ['text-center']}]},
          'url_replace': [], 
          'controls': {'min_temp': min_temp, 'url_base64': True, 'add_video_to_videolibrary': True, 'cnt_tot': 15, 
                       'get_lang': False, 'reverse': False, 'videolab_status': True, 'tmdb_extended_info': True, 'seasons_search': True, 
-                      'host_torrent': host_torrent, 'btdigg': True, 'duplicates': [], 'dup_list': 'title', 
+                      'host_torrent': host_torrent, 'btdigg': True, 'btdigg_search': True, 'duplicates': [], 'dup_list': 'title', 
                       'force_find_last_page': [5, 999, 'url'], 'btdigg_quality_control': True},
          'timeout': timeout}
 AlfaChannel = DictionaryAllChannel(host, movie_path=movie_path, tv_path=tv_path, canonical=canonical, finds=finds, 

--- a/plugin.video.alfa/channels/dontorrent.py
+++ b/plugin.video.alfa/channels/dontorrent.py
@@ -25,9 +25,9 @@ forced_proxy_opt = 'ProxySSL'
 canonical = {
              'channel': 'dontorrent', 
              'host': config.get_setting("current_host", 'dontorrent', default=''), 
-             'host_alt': ["https://dontorrent.capetown/", "https://www2.dontorrent.fr/", "https://tomadivx.net/",
+             'host_alt': ["https://dontorrent.yokohama/", "https://www2.dontorrent.fr/", "https://tomadivx.net/",
                           "https://todotorrents.org/"], 
-             'host_black_list': ["https://dontorrent.cymru/", "https://dontorrent.contact/", 
+             'host_black_list': ["https://dontorrent.capetown/", "https://dontorrent.cymru/", "https://dontorrent.contact/", 
                                  "https://dontorrent.nagoya/", "https://dontorrent.wales/", "https://dontorrent.joburg/", 
                                  "https://dontorrent.party/", "https://dontorrent.durban/", "https://dontorrent.rodeo/",
                                  "https://dontorrent.boston/", "https://dontorrent.tokyo/", "https://dontorrent.bond/",

--- a/plugin.video.alfa/core/httptools.py
+++ b/plugin.video.alfa/core/httptools.py
@@ -1271,7 +1271,7 @@ def downloadpage(url, **opt):
                                                     and ', Proxy Web' in proxy_data.get('stat', '') \
                                                     and proxy_data.get('web_name') == 'croxyproxy.com' \
                                                     and opt.get('error_check', True):
-            update_alfa_domain_web_list(url, 'Timeout=%s' % opt['timeout'], proxy_data, **opt)
+            update_alfa_domain_web_list(url, 'Timeout=%s' % str(opt['timeout']), proxy_data, **opt)
 
             if not alfa_domain_web_list or not alfa_domain_web_list.get(proxy_data.get('web_name', ''), []):
                 from core import filetools

--- a/plugin.video.alfa/lib/AlfaChannelHelper.py
+++ b/plugin.video.alfa/lib/AlfaChannelHelper.py
@@ -1485,7 +1485,8 @@ class DictionaryAllChannel(AlfaChannelHelper):
         if not filter_languages: filter_languages = 0
 
         self.btdigg = finds.get('controls', {}).get('btdigg', False) and config.get_setting('find_alt_link_option', item.channel, default=False)
-        self.btdigg_search = self.btdigg and config.get_setting('find_alt_search', item.channel, default=False)
+        self.btdigg_search = self.btdigg and finds.get('controls', {}).get('btdigg_search', False) \
+                                         and config.get_setting('find_alt_search', item.channel, default=False)
         #if self.btdigg: self.cnt_tot = finds_controls.get('cnt_tot', 20)
         if item.texto: item.texto = item.texto.replace('%20', ' ').replace('+', ' ').strip()
         if item.btdigg and item.c_type == 'search':
@@ -1592,8 +1593,10 @@ class DictionaryAllChannel(AlfaChannelHelper):
             idioma_busqueda_org = idioma_busqueda
             idioma_busqueda_save = ''
             idioma_busqueda_VO = IDIOMAS_TMDB[2]                                # Idioma para VO: Local,VO
-            self.btdigg = finds.get('controls', {}).get('btdigg', False) and config.get_setting('find_alt_link_option', item.channel, default=False)
-            self.btdigg_search = self.btdigg and config.get_setting('find_alt_search', item.channel, default=False)
+            self.btdigg = finds.get('controls', {}).get('btdigg', False) \
+                                             and config.get_setting('find_alt_link_option', item.channel, default=False)
+            self.btdigg_search = self.btdigg and finds.get('controls', {}).get('btdigg_search', False) \
+                                             and config.get_setting('find_alt_search', item.channel, default=False)
 
             # Buscamos la próxima página
             if soup:
@@ -1959,7 +1962,8 @@ class DictionaryAllChannel(AlfaChannelHelper):
         forced_proxy_opt = finds_controls.get('forced_proxy_opt', None) or kwargs.pop('forced_proxy_opt', None)
 
         self.btdigg = finds.get('controls', {}).get('btdigg', False) and config.get_setting('find_alt_link_option', item.channel, default=False)
-        self.btdigg_search = self.btdigg and config.get_setting('find_alt_search', item.channel, default=False)
+        self.btdigg_search = self.btdigg and finds.get('controls', {}).get('btdigg_search', False) \
+                                         and config.get_setting('find_alt_search', item.channel, default=False)
 
         if section_list:
             for genre, url in list(section_list.items()):
@@ -2027,7 +2031,8 @@ class DictionaryAllChannel(AlfaChannelHelper):
         headers = item.headers or finds_controls.get('headers', {}) or headers
         url_replace = self.url_replace = self.finds.get('url_replace', []) or self.url_replace
         self.btdigg = finds.get('controls', {}).get('btdigg', False) and config.get_setting('find_alt_link_option', item.channel, default=False)
-        self.btdigg_search = self.btdigg and config.get_setting('find_alt_search', item.channel, default=False)
+        self.btdigg_search = self.btdigg and finds.get('controls', {}).get('btdigg_search', False) \
+                                         and config.get_setting('find_alt_search', item.channel, default=False)
         
         for elem in matches:
             if not elem.get('url'): continue
@@ -2123,7 +2128,8 @@ class DictionaryAllChannel(AlfaChannelHelper):
         if not matches_post and item.matches_post: matches_post = item.matches_post
 
         self.btdigg = finds_controls.get('btdigg', False) and config.get_setting('find_alt_link_option', item.channel, default=False)
-        self.btdigg_search = self.btdigg and config.get_setting('find_alt_search', item.channel, default=False)
+        self.btdigg_search = self.btdigg and finds.get('controls', {}).get('btdigg_search', False) \
+                                         and config.get_setting('find_alt_search', item.channel, default=False)
         btdigg_contentSeason = 1
 
         AHkwargs = {'url': item.url, 'soup': soup, 'finds': finds, 'kwargs': kwargs, 'function': 'seasons'}
@@ -2353,7 +2359,8 @@ class DictionaryAllChannel(AlfaChannelHelper):
         idioma_busqueda_save = ''
         idioma_busqueda_VO = IDIOMAS_TMDB[2]                                    # Idioma para VO: Local,VO
         self.btdigg = finds.get('controls', {}).get('btdigg', False) and config.get_setting('find_alt_link_option', item.channel, default=False)
-        self.btdigg_search = self.btdigg and config.get_setting('find_alt_search', item.channel, default=False)
+        self.btdigg_search = self.btdigg and finds.get('controls', {}).get('btdigg_search', False) \
+                                         and config.get_setting('find_alt_search', item.channel, default=False)
 
         for elem in matches:
             elem['season'] = int(scrapertools.find_single_match(str(elem.get('season', '1')), r'\d+') or '1')
@@ -2549,7 +2556,8 @@ class DictionaryAllChannel(AlfaChannelHelper):
         if not matches_post and item.matches_post: matches_post = item.matches_post
 
         self.btdigg = finds_controls.get('btdigg', False) and config.get_setting('find_alt_link_option', item.channel, default=False)
-        self.btdigg_search = self.btdigg and config.get_setting('find_alt_search', item.channel, default=False)
+        self.btdigg_search = self.btdigg and finds.get('controls', {}).get('btdigg_search', False) \
+                                         and config.get_setting('find_alt_search', item.channel, default=False)
 
         AHkwargs = {'url': item.url, 'soup': soup, 'kwargs': kwargs, 'finds': finds, 'function': 'episodes'}
         AHkwargs['matches_post_list_all'] = kwargs.pop('matches_post_list_all', None)
@@ -2673,7 +2681,8 @@ class DictionaryAllChannel(AlfaChannelHelper):
         idioma_busqueda_save = ''
         idioma_busqueda_VO = IDIOMAS_TMDB[2]                                    # Idioma para VO: Local,VO
         self.btdigg = finds.get('controls', {}).get('btdigg', False) and config.get_setting('find_alt_link_option', item.channel, default=False)
-        self.btdigg_search = self.btdigg and config.get_setting('find_alt_search', item.channel, default=False)
+        self.btdigg_search = self.btdigg and finds.get('controls', {}).get('btdigg_search', False) \
+                                         and config.get_setting('find_alt_search', item.channel, default=False)
 
         AHkwargs['matches'] = matches
         if self.DEBUG: logger.debug('MATCHES (%s/%s): %s' % (len(matches), len(str(matches)), str(matches)[:SIZE_MATCHES]))
@@ -2922,7 +2931,8 @@ class DictionaryAllChannel(AlfaChannelHelper):
         matches_post_episodes = None
 
         self.btdigg = finds_controls.get('btdigg', False) and config.get_setting('find_alt_link_option', item.channel, default=False)
-        self.btdigg_search = self.btdigg and config.get_setting('find_alt_search', item.channel, default=False)
+        self.btdigg_search = self.btdigg and finds.get('controls', {}).get('btdigg_search', False) \
+                                         and config.get_setting('find_alt_search', item.channel, default=False)
         btdig_in_use = False
 
         AHkwargs = {'url': item.url, 'soup': soup, 'finds': finds, 'kwargs': kwargs, 'function': 'get_video_options', 'videolibrary': False}
@@ -3092,7 +3102,8 @@ class DictionaryAllChannel(AlfaChannelHelper):
         url_replace = self.url_replace = self.finds.get('url_replace', []) or self.url_replace
         url_base64 = finds_controls.get('url_base64', True)
         self.btdigg = finds.get('controls', {}).get('btdigg', False) and config.get_setting('find_alt_link_option', item.channel, default=False)
-        self.btdigg_search = self.btdigg and config.get_setting('find_alt_search', item.channel, default=False)
+        self.btdigg_search = self.btdigg and finds.get('controls', {}).get('btdigg_search', False) \
+                                         and config.get_setting('find_alt_search', item.channel, default=False)
 
         AHkwargs['matches'] = matches
         if self.DEBUG: logger.debug('MATCHES (%s/%s): %s' % (len(matches), len(str(matches)), str(matches)[:SIZE_MATCHES]))

--- a/plugin.video.alfa/lib/AlfaChannelHelper.py
+++ b/plugin.video.alfa/lib/AlfaChannelHelper.py
@@ -107,6 +107,7 @@ class AlfaChannelHelper:
         self.canonical = canonical
         self.finds = finds
         self.finds_updated = {}
+        self.finds_controls_updated = {}
         self.profile = self.finds.get('controls', {}).get('profile', DEFAULT)
         self.url_replace = url_replace
         self.Window_IsMedia = True
@@ -151,9 +152,14 @@ class AlfaChannelHelper:
         try:
             self.domains_updated = jsontools.load(window.getProperty("alfa_domains_updated") or '{}')
             if self.channel in self.domains_updated and 'finds' in self.domains_updated[self.channel]:
-                self.finds_updated = self.domains_updated[self.channel].pop('finds', '')
-                for key, value in self.finds_updated.items():
-                    self.finds_updated[key] = eval('%s' % value)
+                finds_updated = self.domains_updated[self.channel].pop('finds', '')
+                for key, value in finds_updated.items():
+                    if key not in ['controls']:
+                        self.finds_updated[key] = eval('%s' % value)
+                    else:
+                        for key_c, value_c in finds_updated[key].items():
+                            self.finds_controls_updated[key_c] = eval('%s' % value_c)
+
             if not self.TEST_ON_AIR and not self.CACHING_DOMAINS and 'host' in self.canonical \
                                     and 'host_alt' in self.canonical and 'host_black_list' in self.canonical:
                 if self.channel in self.domains_updated and (self.domains_updated[self.channel].get('host_alt') \
@@ -1403,8 +1409,9 @@ class DictionaryAllChannel(AlfaChannelHelper):
 
         if not finds: finds = self.finds.copy()
         finds.update(self.finds_updated)
+        finds['controls'].update(self.finds_controls_updated)
         self.finds = finds.copy()
-        if self.DEBUG: logger.debug('FINDS: %s' % self.finds_updated)
+        if self.DEBUG: logger.debug('FINDS: %s; %s' % (self.finds_updated, self.finds_controls_updated))
         if self.DEBUG: logger.debug('FINDS: %s' % finds)
         finds_out = finds.get('find', {})
         if item.c_type == 'search' and finds.get('search', {}): finds_out = finds.get('search', {})
@@ -1933,6 +1940,7 @@ class DictionaryAllChannel(AlfaChannelHelper):
 
         if not finds: finds = self.finds.copy()
         finds.update(self.finds_updated)
+        finds['controls'].update(self.finds_controls_updated)
         self.finds = finds.copy()
         finds_out = finds.get('categories', {})
         finds_controls = finds.get('controls', {})
@@ -2113,6 +2121,7 @@ class DictionaryAllChannel(AlfaChannelHelper):
 
         if not finds: finds = self.finds.copy()
         finds.update(self.finds_updated)
+        finds['controls'].update(self.finds_controls_updated)
         self.finds = finds.copy()
         finds_out = finds.get('seasons', {})
         finds_season_num = finds.get('season_num', {})
@@ -2543,6 +2552,7 @@ class DictionaryAllChannel(AlfaChannelHelper):
 
         if not finds: finds = self.finds.copy()
         finds.update(self.finds_updated)
+        finds['controls'].update(self.finds_controls_updated)
         self.finds = finds.copy()
         finds_out = finds.get('episodes', {})
         finds_episode_num = finds.get('episode_num', [])
@@ -2914,6 +2924,7 @@ class DictionaryAllChannel(AlfaChannelHelper):
 
         if not finds: finds = self.finds.copy()
         finds.update(self.finds_updated)
+        finds['controls'].update(self.finds_controls_updated)
         self.finds = finds.copy()
         finds_out = finds.get('findvideos', {})
         finds_out_episodes = finds.get('episodes', {})
@@ -3335,6 +3346,7 @@ class DictionaryAdultChannel(AlfaChannelHelper):
 
         if not finds: finds = self.finds.copy()
         finds.update(self.finds_updated)
+        finds['controls'].update(self.finds_controls_updated)
         self.finds = finds.copy()
         if self.DEBUG: logger.debug('FINDS: %s' % finds)
         finds_out = finds.get('find', {})
@@ -3783,6 +3795,7 @@ class DictionaryAdultChannel(AlfaChannelHelper):
 
         if not finds: finds = self.finds.copy()
         finds.update(self.finds_updated)
+        finds['controls'].update(self.finds_controls_updated)
         self.finds = finds.copy()
         finds_out = finds.get('categories', {})
         finds_next_page = finds.get('next_page', {})
@@ -4232,6 +4245,7 @@ class DictionaryAdultChannel(AlfaChannelHelper):
 
         if not finds: finds = self.finds.copy()
         finds.update(self.finds_updated)
+        finds['controls'].update(self.finds_controls_updated)
         self.finds = finds.copy()
         finds_out = finds.get('findvideos', {})
         finds_out_episodes = finds.get('episodes', {})
@@ -4552,6 +4566,7 @@ class DooPlay(AlfaChannelHelper):
                                'timeout': 5}
 
         self.finds_updated = {}
+        self.finds_controls_updated = {}
         self.url = self.movie_path = self.tv_path = self.movie_action = self.tv_action = ''
         self.timeout = finds.get('control', {}).get('timeout', 5)
         self.doo_url = "%swp-admin/admin-ajax.php" % self.host

--- a/plugin.video.alfa/lib/generictools.py
+++ b/plugin.video.alfa/lib/generictools.py
@@ -1863,6 +1863,7 @@ def AH_find_btdigg_list_all_from_channel_py(self, item, matches=[], matches_inde
                     elem_json['url'] = elem.a.get("href", "")
                     elem_json['title'] = elem.find('div', class_='card-body').find('h3', class_='title').get_text(strip=True)
                     elem_json['year'] = scrapertools.find_single_match(elem_json['title'], r'\((\d{4})\)') or '-'
+                    if elem_json['year'] in ['720', '1080', '2160']: elem_json['year'] = '-'
                     elem_json['thumbnail'] = elem.find('img').get("src", "")
                     if elem_json['thumbnail'].startswith('//'): elem_json['thumbnail'] = 'https:%s' % elem_json['thumbnail']
                     elem_json['quality'] = elem.find('div', class_='quality').get_text(strip=True)
@@ -1897,6 +1898,7 @@ def AH_find_btdigg_list_all_from_channel_py(self, item, matches=[], matches_inde
                     elem_json['url'] = self.urljoin(host_alt, elem.get('guid', ''))
                     elem_json['title'] = scrapertools.find_single_match(elem.get('torrentName', ''), r'(.*?)\[').strip()
                     elem_json['year'] = scrapertools.find_single_match(re.sub(r'(?i)cap\.\d+', '', elem_json['title']), '.+?'+patron_year) or '-'
+                    if elem_json['year'] in ['720', '1080', '2160']: elem_json['year'] = '-'
                     elem_json['thumbnail'] = self.urljoin(host_alt, elem.get('imagen', ''))
                     elem_json['quality'] = elem.get('calidad', '')
                     elem_json['quality'] = elem_json['quality'].replace('creeener', 'creener')\
@@ -2360,6 +2362,7 @@ def AH_find_btdigg_list_all_from_BTDIGG(self, item, matches=[], matches_index={}
 
                         elem_json['title'] = elem.get('title', '').replace(btdigg_label_B, '')
                         elem_json['year'] = scrapertools.find_single_match(re.sub(r'(?i)cap\.\d+', '', elem_json['title']), '.+?'+patron_year) or '-'
+                        if elem_json['year'] in ['720', '1080', '2160']: elem_json['year'] = '-'
                         if scrapertools.find_single_match(elem_json['title'], patron_title).strip():
                             elem_json['title'] = scrapertools.find_single_match(elem_json['title'], patron_title).strip()
                         elif scrapertools.find_single_match(elem_json['title'], patron_title_b).strip():
@@ -2780,6 +2783,7 @@ def CACHING_find_btdigg_list_all_NEWS_from_BTDIGG_(options=None):
                     if elem_show.get('season_search', ''): elem_json['season_search'] = elem_show['season_search']
                     elem_json['title'] = elem_show.get('title', '').replace(btdigg_label_B, '')
                     elem_json['year'] = scrapertools.find_single_match(re.sub(r'(?i)cap\.\d+', '', elem_json['title']), '.+?'+patron_year) or '-'
+                    if elem_json['year'] in ['720', '1080', '2160']: elem_json['year'] = '-'
                     if scrapertools.find_single_match(elem_json['title'], patron_title).strip():
                         elem_json['title'] = scrapertools.find_single_match(elem_json['title'], patron_title).strip()
                     elif scrapertools.find_single_match(elem_json['title'], patron_title_b).strip():
@@ -3072,9 +3076,9 @@ def AH_find_btdigg_seasons(self, item, matches=[], domain_alt=channel_py, **AHkw
 
     logger.debug('contentSeason: %s; season_high: %s; number_of_seasons: %s' \
                   % (contentSeason, season_high, item.infoLabels['number_of_seasons']))
-    if (item.infoLabels['number_of_seasons'] in season_high and contentSeason == 0) \
+    if (item.infoLabels.get('number_of_seasons', 0) in season_high and contentSeason == 0) \
                          or (contentSeason > 0 and contentSeason in season_high \
-                         and season_high[-1] >= item.infoLabels['number_of_seasons']):
+                         and season_high[-1] >= item.infoLabels.get('number_of_seasons', item.contentSeason or 99)):
         return matches
 
     try:
@@ -3381,7 +3385,7 @@ def AH_find_btdigg_episodes(self, item, matches=[], domain_alt=channel_py, **AHk
         else: from lib.alfaresolver_py3 import find_alternative_link
 
         if BTDIGG_URL_SEARCH in item.url_tvshow and not item.library_playcounts and (epis_index.get(last_episode_to_air, []) \
-                                                                                     or item.contentSeason > item.infoLabels['number_of_seasons']):
+                                                or item.contentSeason > item.infoLabels.get('number_of_seasons', 99)):
             return matches
         if not channel_py_strict and not l_p_missing:
             sxe_max = '%sx%s' % (item.infoLabels['number_of_seasons'], str(episode_max).zfill(2))

--- a/plugin.video.alfa/lib/generictools.py
+++ b/plugin.video.alfa/lib/generictools.py
@@ -2195,6 +2195,7 @@ def AH_find_btdigg_list_all_from_BTDIGG(self, item, matches=[], matches_index={}
     matches_len = len(matches_btdigg)
 
     controls = self.finds.get('controls', {}) if self else {}
+    btdigg_search = controls.get('btdigg_search', True)
     disable_cache = True
     quality_control = AHkwargs.get('btdigg_quality_control', controls.get('btdigg_quality_control', False))
     if item.btdigg: quality_control = False
@@ -3037,6 +3038,7 @@ def AH_find_btdigg_seasons(self, item, matches=[], domain_alt=channel_py, **AHkw
     ASSISTANT_REMOTE = True if config.get_setting("assistant_mode").lower() == 'otro' else False
 
     controls = self.finds.get('controls', {})
+    btdigg_search = controls.get('btdigg_search', True)
     url = AHkwargs.pop('url', item.url)
     contentSeason = AHkwargs.pop('btdigg_contentSeason', controls.get('btdigg_contentSeason', 0))
     disable_cache = True if (not 'btdigg_cache' in AHkwargs  and not 'btdigg_cache' in controls) else \
@@ -3079,6 +3081,9 @@ def AH_find_btdigg_seasons(self, item, matches=[], domain_alt=channel_py, **AHkw
     if (item.infoLabels.get('number_of_seasons', 0) in season_high and contentSeason == 0) \
                          or (contentSeason > 0 and contentSeason in season_high \
                          and season_high[-1] >= item.infoLabels.get('number_of_seasons', item.contentSeason or 99)):
+        return matches
+
+    if not btdigg_search:
         return matches
 
     try:
@@ -3249,6 +3254,7 @@ def AH_find_btdigg_episodes(self, item, matches=[], domain_alt=channel_py, **AHk
     ASSISTANT_REMOTE = True if config.get_setting("assistant_mode", default="").lower() == 'otro' else False
 
     controls = self.finds.get('controls', {})
+    btdigg_search = controls.get('btdigg_search', True)
     contentSeason = AHkwargs.pop('btdigg_contentSeason', controls.get('btdigg_contentSeason', 0))
     disable_cache = True if str(item.infoLabels['number_of_seasons']) == '1' else \
                     not AHkwargs.pop('btdigg_cache', controls.get('btdigg_cache', True))
@@ -3372,6 +3378,9 @@ def AH_find_btdigg_episodes(self, item, matches=[], domain_alt=channel_py, **AHk
 
             except Exception:
                 logger.error(traceback.format_exc())
+
+    if not btdigg_search:
+        return matches
 
     try:
         if canonical.get('global_search_cancelled', False) or (config.GLOBAL_SEARCH_CANCELLED \
@@ -3548,6 +3557,7 @@ def AH_find_btdigg_findvideos(self, item, matches=[], domain_alt=channel_py, **A
     ASSISTANT_REMOTE = True if config.get_setting("assistant_mode").lower() == 'otro' else False
     
     controls = self.finds.get('controls', {}) if self else {}
+    btdigg_search = controls.get('btdigg_search', True)
     contentSeason = AHkwargs.pop('btdigg_contentSeason', controls.get('btdigg_contentSeason', 0))
     disable_cache = True if (not 'btdigg_cache' in AHkwargs  and not 'btdigg_cache' in controls) else \
                     not AHkwargs.pop('btdigg_cache', controls.get('btdigg_cache', True))
@@ -3593,7 +3603,11 @@ def AH_find_btdigg_findvideos(self, item, matches=[], domain_alt=channel_py, **A
                                 if not matches_cached.get('language', []): matches_cached['language'] = item.language or ['CAST']
                                 matches.append(matches_cached.copy())
 
-    if found or AHkwargs.pop('btdigg_lookup', False) or (item.matches and item.channel != 'videolibrary' and item.contentChannel != 'videolibrary' and item.from_channel != 'videolibrary'):
+    if found or AHkwargs.pop('btdigg_lookup', False) or (item.matches and item.channel != 'videolibrary' \
+                                                     and item.contentChannel != 'videolibrary' and item.from_channel != 'videolibrary'):
+        return matches
+
+    if not btdigg_search:
         return matches
 
     if matches and isinstance(matches[0], list):

--- a/plugin.video.alfa/platformcode/config.py
+++ b/plugin.video.alfa/platformcode/config.py
@@ -225,6 +225,7 @@ def get_platform(full_version=False):
                '16': 'MyVideos99.db', '17': 'MyVideos107.db', '18': 'MyVideos116.db',
                '19': 'MyVideos119.db', '20': 'MyVideos121.db', '21': 'MyVideos122.db'}
 
+    from platformcode import logger
     if not __kodi_version__:
         num_version = xbmc.getInfoLabel('System.BuildVersion')
         num_version = re.match("\d+\.\d+", num_version).group(0)
@@ -237,9 +238,9 @@ def get_platform(full_version=False):
             __kodi_version__['platform'] = "kodi-" + __kodi_version__['name_version']
 
     if full_version:
-        return __kodi_version__
+        return __kodi_version__.copy()
     else:
-        return __kodi_version__['platform']
+        return __kodi_version__.copy()['platform']
 
 
 def is_xbmc():

--- a/plugin.video.alfa/servers/torrent.py
+++ b/plugin.video.alfa/servers/torrent.py
@@ -1875,14 +1875,14 @@ def torrent_dirs():
     torrent_paths = copy.deepcopy(torrent_paths_org)
     
     try:
-        torrent_paths['TORR_opt'] = int(config.get_setting("torrent_client", server="torrent", default=0, debug=DEBUG))
+        torrent_paths['TORR_opt'] = int(config.get_setting("torrent_client", server="torrent", default=0))
     except Exception:
         from platformcode import custom_code
         custom_code.verify_data_jsons(json_file='torrent_data.json')
         try:
-            if config.get_setting("torrent_client", server="torrent", default=0, debug=DEBUG) == None:
-                config.set_setting("torrent_client", 0, server="torrent", debug=DEBUG)
-            torrent_paths['TORR_opt'] = int(config.get_setting("torrent_client", server="torrent", default=0, debug=DEBUG))
+            if config.get_setting("torrent_client", server="torrent", default=0) == None:
+                config.set_setting("torrent_client", 0, server="torrent")
+            torrent_paths['TORR_opt'] = int(config.get_setting("torrent_client", server="torrent", default=0))
         except Exception:
             torrent_paths['TORR_opt'] = 0
             torrent_json_path = filetools.join(config.get_data_path(), 'settings_servers', 'torrent_data.json')
@@ -1895,12 +1895,12 @@ def torrent_dirs():
         torrent_paths['TORR_client'] = scrapertools.find_single_match(torrent_options[torrent_paths['TORR_opt']-1][0], ':\s*(\w+)').lower()
     if torrent_paths['TORR_opt'] == 1: torrent_paths['TORR_client'] = 'BT'
     if torrent_paths['TORR_opt'] == 2: torrent_paths['TORR_client'] = 'MCT'
-    torrent_paths['TORR_libtorrent_path'] = config.get_setting("libtorrent_path", server="torrent", default='', debug=DEBUG)
-    torrent_paths['TORR_unrar_path'] = config.get_setting("unrar_path", server="torrent", default='', debug=DEBUG)
-    torrent_paths['TORR_background_download'] = config.get_setting("mct_background_download", server="torrent", default=True, debug=DEBUG)
-    torrent_paths['TORR_rar_unpack'] = config.get_setting("mct_rar_unpack", server="torrent", default=True, debug=DEBUG)
+    torrent_paths['TORR_libtorrent_path'] = config.get_setting("libtorrent_path", server="torrent", default='')
+    torrent_paths['TORR_unrar_path'] = config.get_setting("unrar_path", server="torrent", default='')
+    torrent_paths['TORR_background_download'] = config.get_setting("mct_background_download", server="torrent", default=True)
+    torrent_paths['TORR_rar_unpack'] = config.get_setting("mct_rar_unpack", server="torrent", default=True)
     torr_client = ''
-    downloadpath = config.get_setting("downloadpath", default='', debug=DEBUG)
+    downloadpath = config.get_setting("downloadpath", default='')
     
     for torr_client_g, torr_client_url in torrent_options:
         # Localizamos el path de descarga del .torrent y la carpeta de almacenamiento de los archivos .torrent
@@ -1921,23 +1921,23 @@ def torrent_dirs():
                 logger.error(traceback.format_exc())
         if torr_client == 'BT':
             try:
-                if not config.get_setting("bt_download_path", server="torrent", default='', debug=DEBUG) and downloadpath:
-                    config.set_setting("bt_download_path", downloadpath, server="torrent", debug=DEBUG)
+                if not config.get_setting("bt_download_path", server="torrent", default='') and downloadpath:
+                    config.set_setting("bt_download_path", downloadpath, server="torrent")
                 torrent_paths['BT'] = filetools.join(str(config.get_setting("bt_download_path", \
-                            server="torrent", default='', debug=DEBUG)), 'BT-torrents')
+                            server="torrent", default='')), 'BT-torrents')
                 torrent_paths['BT_torrents'] = filetools.join(torrent_paths['BT'], '.cache')
-                torrent_paths['BT_buffer'] = config.get_setting("bt_buffer", server="torrent", default="50", debug=DEBUG)
+                torrent_paths['BT_buffer'] = config.get_setting("bt_buffer", server="torrent", default="50")
             except Exception:
                 logger.error(traceback.format_exc(1))
         elif torr_client == 'MCT':
             try:
-                if not config.get_setting("mct_download_path", server="torrent", default='', debug=DEBUG) and downloadpath:
-                    config.set_setting("mct_download_path", downloadpath, server="torrent", debug=DEBUG)
+                if not config.get_setting("mct_download_path", server="torrent", default='') and downloadpath:
+                    config.set_setting("mct_download_path", downloadpath, server="torrent")
                 torrent_paths['MCT'] = filetools.join(str(config.get_setting("mct_download_path", \
-                            server="torrent", default='', debug=DEBUG)), 'MCT-torrent-videos')
+                            server="torrent", default='')), 'MCT-torrent-videos')
                 torrent_paths['MCT_torrents'] = filetools.join(str(config.get_setting("mct_download_path", \
-                            server="torrent", default='', debug=DEBUG)), 'MCT-torrents')
-                torrent_paths['MCT_buffer'] = config.get_setting("mct_buffer", server="torrent", default="50", debug=DEBUG)
+                            server="torrent", default='')), 'MCT-torrents')
+                torrent_paths['MCT_buffer'] = config.get_setting("mct_buffer", server="torrent", default="50")
             except Exception:
                 logger.error(traceback.format_exc(1))
         elif 'torrenter' in torr_client.lower():
@@ -2315,7 +2315,7 @@ def restart_unfinished_downloads():
             while not monitor.abortRequested():
 
                 torrent_paths = torrent_dirs()
-                DOWNLOAD_LIST_PATH = config.get_setting("downloadlistpath", debug=DEBUG)
+                DOWNLOAD_LIST_PATH = config.get_setting("downloadlistpath")
                 LISTDIR = sorted(filetools.listdir(DOWNLOAD_LIST_PATH))
 
                 for fichero in LISTDIR:
@@ -2379,7 +2379,7 @@ def restart_unfinished_downloads():
                         
                         if item.downloadStatus in [1, 3]:
                             continue
-                        if item.server != 'torrent' and config.get_setting("DOWNLOADER_in_use", "downloads", debug=DEBUG):
+                        if item.server != 'torrent' and config.get_setting("DOWNLOADER_in_use", "downloads"):
                             continue
                         if torr_client not in ['BT', 'MCT', 'TORRENTER', 'QUASAR', 'ELEMENTUM', 'TORREST'] and item.downloadProgress != 0:
                             continue
@@ -2407,7 +2407,7 @@ def restart_unfinished_downloads():
                                     item.downloadServer['url'] = new_torrent_url
                                     item.url = new_torrent_url
 
-                            if not config.get_setting("LIBTORRENT_in_use", server="torrent", default=False, debug=DEBUG) or item.server != 'torrent':
+                            if not config.get_setting("LIBTORRENT_in_use", server="torrent", default=False) or item.server != 'torrent':
                                 try:
                                     if isinstance(item.downloadProgress, (int, float)):
                                         item.downloadProgress += 1
@@ -2452,9 +2452,9 @@ def restart_unfinished_downloads():
                         if xbmc.abortRequested: 
                             return
                         xbmc.sleep(5*1000)
-                    if config.get_setting("RESTART_DOWNLOADS", "downloads", default=False, debug=DEBUG):    # ... a menos que se active externamente
+                    if config.get_setting("RESTART_DOWNLOADS", "downloads", default=False):    # ... a menos que se active externamente
                         logger.info('RESTART_DOWNLOADS Activado externamente')
-                        config.set_setting("RESTART_DOWNLOADS", False, "downloads", debug=DEBUG) 
+                        config.set_setting("RESTART_DOWNLOADS", False, "downloads") 
                         break
     except Exception:
         logger.error(traceback.format_exc())
@@ -2521,13 +2521,13 @@ def relaunch_torrent_monitoring(item, torr_client='', torrent_paths=[]):
         if item.referer: referer = item.referer
         if item.post: post = item.post
 
-        download_path = config.get_setting('downloadpath', default='', debug=DEBUG)
+        download_path = config.get_setting('downloadpath', default='')
         videolibrary_path = config.get_videolibrary_path()
         videolibrary_path_local = videolibrary_path
         if item.contentType == 'movie':
-            folder = config.get_setting("folder_movies", debug=DEBUG)           # películas
+            folder = config.get_setting("folder_movies")                        # películas
         else:
-            folder = config.get_setting("folder_tvshows", debug=DEBUG)          # o series
+            folder = config.get_setting("folder_tvshows")                       # o series
         
         if scrapertools.find_single_match(videolibrary_path,'(^\w+:\/\/)'):     # Si es una conexión REMOTA, usamos userdata local
             videolibrary_path_local = config.get_data_path()
@@ -2584,10 +2584,10 @@ def check_seen_torrents():
         
         global torrent_paths
         if not torrent_paths: torrent_paths = torrent_dirs()
-        DOWNLOAD_PATH_ALFA = config.get_setting("downloadpath", debug=DEBUG)
-        DOWNLOAD_LIST_PATH = config.get_setting("downloadlistpath", debug=DEBUG)
-        MOVIES = filetools.join(config.get_videolibrary_path(), config.get_setting("folder_movies", debug=DEBUG))
-        SERIES = filetools.join(config.get_videolibrary_path(), config.get_setting("folder_tvshows", debug=DEBUG))
+        DOWNLOAD_PATH_ALFA = config.get_setting("downloadpath")
+        DOWNLOAD_LIST_PATH = config.get_setting("downloadlistpath")
+        MOVIES = filetools.join(config.get_videolibrary_path(), config.get_setting("folder_movies"))
+        SERIES = filetools.join(config.get_videolibrary_path(), config.get_setting("folder_tvshows"))
         LISTDIR = sorted(filetools.listdir(DOWNLOAD_LIST_PATH))
         nun_records = 0
         
@@ -2611,7 +2611,7 @@ def check_seen_torrents():
                 
                 # Si no viene de videoteca que crean item.strm_path y item.nfo
                 if not item.strm_path and filename and item.infoLabels['IMDBNumber']:
-                    if config.get_setting("videolibrary_original_title_in_content_folder", debug=DEBUG) == 1 and item.infoLabels['originaltitle']:
+                    if config.get_setting("videolibrary_original_title_in_content_folder") == 1 and item.infoLabels['originaltitle']:
                         base_name = item.infoLabels['originaltitle']
                     else:
                         if item.infoLabels['mediatype'] == 'movie':
@@ -2622,7 +2622,7 @@ def check_seen_torrents():
                         base_name = unicode(filetools.validate_path(base_name.replace('/', '-')), "utf8").encode("utf8")
                     else:
                         base_name = filetools.validate_path(base_name.replace('/', '-'))
-                    if config.get_setting("videolibrary_lowercase_title_in_content_folder", debug=DEBUG) == 0:
+                    if config.get_setting("videolibrary_lowercase_title_in_content_folder") == 0:
                         base_name = base_name.lower()
                     path = ("%s [%s]" % (base_name, item.infoLabels['IMDBNumber'])).strip()
                     if item.infoLabels['mediatype'] == 'movie':


### PR DESCRIPTION
- Servidor Torrent: quitar DEBUG en llamadas a config
- Generictools: Error en búsquedas BTDigg
- Httptools: corrección de error en recuperación de ProxySSL cuando el timeout tiene formato (x, y)
- Config: evitar que módulos llamantes corrompan el dict __kodi_version__ retornado
- Dontorrent: cambio de dominio
- Permite desactivar búsquedas BTDigg temporalmente