### PR TITLE
No editar las direcciones de proxy_addr_forced + respetar valor de tmdb_active

### DIFF
--- a/plugin.video.alfa/core/httptools.py
+++ b/plugin.video.alfa/core/httptools.py
@@ -503,12 +503,13 @@ def check_proxy(url, **opt):
         url = proxy_data["url"]
         proxy_data["stat"] = proxy_data.get("stat", "").replace(",P", ", P")
 
-        if proxy_data.get("dict", {}).get("https", ""):
-            proxy_data["dict"]["http"] = str("http://" + proxy_data["dict"]["https"])
-            proxy_data["dict"]["https"] = proxy_data["dict"]["http"]
-        elif proxy_data.get("dict", {}).get("http", ""):
-            proxy_data["dict"]["https"] = str("http://" + proxy_data["dict"]["http"])
-            proxy_data["dict"]["http"] = proxy_data["dict"]["https"]
+        if not "proxy_addr_forced" in proxy_data:
+            if proxy_data.get("dict", {}).get("https", ""):
+                proxy_data["dict"]["http"] = str("http://" + proxy_data["dict"]["https"])
+                proxy_data["dict"]["https"] = proxy_data["dict"]["http"]
+            elif proxy_data.get("dict", {}).get("http", ""):
+                proxy_data["dict"]["https"] = str("http://" + proxy_data["dict"]["http"])
+                proxy_data["dict"]["http"] = proxy_data["dict"]["https"]
 
     return url, proxy_data, opt
 

--- a/plugin.video.alfa/platformcode/launcher.py
+++ b/plugin.video.alfa/platformcode/launcher.py
@@ -151,7 +151,7 @@ def run(item=None):
     item = monkey_patch_modules(item)
 
     try:
-        if not config.get_setting('tmdb_active'):
+        if config.get_setting('tmdb_active') is None:
             config.set_setting('tmdb_active', True)
 
         # Special action for playing a video from the library


### PR DESCRIPTION
Si en un canal yo voy y edito el "canonical" y le pongo un
```
"proxy_addr_forced":  {
    "http": "http://algo",
    "https": "http://algo"
}
```

Lo que hay ahora intenta poner el string "http" o "https" delante de los proxys, rompiendo la configuración porque si hay una petición http al "https" le hará append de "http" y quedará "http://http://algo"

No se si es un bug, por eso dejo el comportamiento anterior pero condicionado a que no le exijas un proxy_addr_forced concreto.

También he puesto (se me olvidó hacer 2 branchs -.-) que respete el valor de tmdb_active de la configuración. En un sistema lento todo lo que añade el infolabels hace que listar los elementos sea muy lento por la serialización de los Item. Además, de que alguna serie da problemas de que se equivoca. Por eso con esto se puede respetar el valor de settings.xml