### PR TITLE
fix(AlfaChannelHelper): corregir asignación de kwargs['alfa_s']

### DIFF
--- a/plugin.video.alfa/lib/AlfaChannelHelper.py
+++ b/plugin.video.alfa/lib/AlfaChannelHelper.py
@@ -274,7 +274,7 @@ class AlfaChannelHelper:
             self.KWARGS.update(kwargs)
             kwargs = copy.deepcopy(self.KWARGS)
         elif self.CACHING_DOMAINS:
-            kwargs['alfa_s': True]
+            kwargs['alfa_s'] = True
 
         #logger.debug('KWARGS: %s' % kwargs)
         response = self.httptools.downloadpage(url, **kwargs)


### PR DESCRIPTION
kwargs['alfa_s': True] usa un objeto slice como clave del dict, lo que lanza TypeError: unhashable type: 'slice' en tiempo de ejecución cuando self.CACHING_DOMAINS es truthy.  
  
La clave 'alfa_s' nunca llegaba a añadirse a kwargs, por lo que httptools.downloadpage() no recibía el parámetro esperado.